### PR TITLE
Add error log for missing installed commands or versions

### DIFF
--- a/Sources/nest/Commands/UninstallCommand.swift
+++ b/Sources/nest/Commands/UninstallCommand.swift
@@ -27,6 +27,15 @@ struct UninstallCommand: AsyncParsableCommand {
         let targetCommand = info[commandName, default: []].filter { command in
             command.version == version || version == nil
         }
+
+        if info[commandName, default: []].isEmpty {
+            logger.error("🪹 \(commandName) doesn't exist.", metadata: .color(.red))
+            Foundation.exit(1)
+        } else if let version, targetCommand.isEmpty {
+            logger.error("🪹 \(commandName) (\(version)) doesn't exist.", metadata: .color(.red))
+            Foundation.exit(1)
+        }
+
         for command in targetCommand {
             try nestFileManager.uninstall(command: commandName, version: command.version)
             logger.info("🗑️ \(commandName) \(command.version) is uninstalled.")

--- a/Sources/nest/Commands/UninstallCommand.swift
+++ b/Sources/nest/Commands/UninstallCommand.swift
@@ -28,11 +28,12 @@ struct UninstallCommand: AsyncParsableCommand {
             command.version == version || version == nil
         }
 
-        if info[commandName, default: []].isEmpty {
-            logger.error("🪹 \(commandName) doesn't exist.", metadata: .color(.red))
-            Foundation.exit(1)
-        } else if let version, targetCommand.isEmpty {
-            logger.error("🪹 \(commandName) (\(version)) doesn't exist.", metadata: .color(.red))
+        guard !targetCommand.isEmpty else {
+            if let version {
+                logger.error("🪹 \(commandName) (\(version)) doesn't exist.", metadata: .color(.red))
+            } else {
+                logger.error("🪹 \(commandName) doesn't exist.", metadata: .color(.red))
+            }
             Foundation.exit(1)
         }
 

--- a/Sources/nest/Commands/UninstallCommand.swift
+++ b/Sources/nest/Commands/UninstallCommand.swift
@@ -29,11 +29,13 @@ struct UninstallCommand: AsyncParsableCommand {
         }
 
         guard !targetCommand.isEmpty else {
-            if let version {
-                logger.error("🪹 \(commandName) (\(version)) doesn't exist.", metadata: .color(.red))
-            } else {
-                logger.error("🪹 \(commandName) doesn't exist.", metadata: .color(.red))
-            }
+            let message: Logger.Message =
+                if let version {
+                    "🪹 \(commandName) (\(version)) doesn't exist."
+                } else {
+                    "🪹 \(commandName) doesn't exist."
+                }
+            logger.error(message, metadata: .color(.red))
             Foundation.exit(1)
         }
 


### PR DESCRIPTION
I added error log for cases where either a command or its version is missing. 
The error messages follow the format used in the `SwitchCommand` implementation.