### PR TITLE
[install.sh] Use artifact bundle when bootstrapping to reduce GitHub API usages

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -15,7 +15,7 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
-./extracted_files/nest.artifactbundle/nest-$VERSION-macos/bin/nest install mtj0928/nest > /dev/null
+./extracted_files/nest.artifactbundle/nest-$VERSION-macos/bin/nest install $ASSET_URL > /dev/null
 rm -rf extracted_files
 echo "🪺 nest was installed at ~/.nest/bin"
 echo "🪺 Please add it to \$PATH"


### PR DESCRIPTION
`nest install mtj0928/nest` will use GitHub API to find its latest release, but that can be avoid by passing the latest release artifact bundle url directly.