### PR TITLE
Rename GitRepositoryClient to AssetRegistryClient

### DIFF
--- a/Sources/NestCLI/ArtifactBundleFetcher.swift
+++ b/Sources/NestCLI/ArtifactBundleFetcher.swift
@@ -8,7 +8,7 @@ public struct ArtifactBundleFetcher {
     private let fileSystem: any FileSystem
     private let fileDownloader: any FileDownloader
     private let nestInfoController: NestInfoController
-    private let repositoryClientBuilder: GitRepositoryClientBuilder
+    private let assetRegistryClientBuilder: AssetRegistryClientBuilder
     private let checksumCalculator: any ChecksumCalculator
     private let tripleDetector: TripleDetector
     private let logger: Logger
@@ -19,7 +19,7 @@ public struct ArtifactBundleFetcher {
         fileSystem: some FileSystem,
         fileDownloader: some FileDownloader,
         nestInfoController: NestInfoController,
-        repositoryClientBuilder: GitRepositoryClientBuilder,
+        assetRegistryClientBuilder: AssetRegistryClientBuilder,
         logger: Logger
     ) {
         self.workingDirectory = workingDirectory
@@ -27,7 +27,7 @@ public struct ArtifactBundleFetcher {
         self.fileSystem = fileSystem
         self.fileDownloader = fileDownloader
         self.nestInfoController = nestInfoController
-        self.repositoryClientBuilder = repositoryClientBuilder
+        self.assetRegistryClientBuilder = assetRegistryClientBuilder
         self.checksumCalculator = SwiftChecksumCalculator(swift: SwiftCommand(executor: executorBuilder.build()))
         self.tripleDetector = TripleDetector(swiftCommand: SwiftCommand(executor: executorBuilder.build()))
         self.logger = logger
@@ -119,8 +119,8 @@ public struct ArtifactBundleFetcher {
             return asset
         }
 
-        let repositoryClient = repositoryClientBuilder.build(for: url)
-        let assetInfo = try await repositoryClient.fetchAssets(repositoryURL: url, version: version)
+        let assetRegistryClient = assetRegistryClientBuilder.build(for: url)
+        let assetInfo = try await assetRegistryClient.fetchAssets(repositoryURL: url, version: version)
         // Choose an asset which may be an artifact bundle.
         guard let selectedAsset = ArtifactBundleAssetSelector().selectArtifactBundle(
             from: assetInfo.assets,

--- a/Sources/NestCLI/ExecutableBinaryPreparer.swift
+++ b/Sources/NestCLI/ExecutableBinaryPreparer.swift
@@ -36,7 +36,7 @@ public struct ExecutableBinaryPreparer {
                 logger.info("🪹 No artifact bundles in the repository.")
             } catch ArtifactBundleFetcherError.unsupportedTriple {
                 logger.info("🪹 No binaries corresponding to the current triple.")
-            } catch GitRepositoryClientError.notFound {
+            } catch AssetRegistryClientError.notFound {
                 logger.info("🪹 No releases in the repository.")
             } catch NestCLIError.alreadyInstalled {
                 logger.info("🪺 The artifact bundle has been already installed.")

--- a/Sources/NestCLI/NestfileController.swift
+++ b/Sources/NestCLI/NestfileController.swift
@@ -3,18 +3,18 @@ import Foundation
 import NestKit
 
 public struct NestfileController: Sendable {
-    private let repositoryClientBuilder: GitRepositoryClientBuilder
+    private let assetRegistryClientBuilder: AssetRegistryClientBuilder
     private let fileSystem: any FileSystem
     private let fileDownloader: any FileDownloader
     private let checksumCalculator: any ChecksumCalculator
 
     public init(
-        repositoryClientBuilder: GitRepositoryClientBuilder,
+        assetRegistryClientBuilder: AssetRegistryClientBuilder,
         fileSystem: some FileSystem,
         fileDownloader: some FileDownloader,
         checksumCalculator: some ChecksumCalculator
     ) {
-        self.repositoryClientBuilder = repositoryClientBuilder
+        self.assetRegistryClientBuilder = assetRegistryClientBuilder
         self.fileSystem = fileSystem
         self.fileDownloader = fileDownloader
         self.checksumCalculator = checksumCalculator
@@ -65,9 +65,9 @@ public struct NestfileController: Sendable {
               case .url(let url) = gitURL
         else { return repository }
 
-        let repositoryClient = repositoryClientBuilder.build(for: url)
+        let assetRegistryClient = assetRegistryClientBuilder.build(for: url)
         let version = resolveVersion(repository: repository, resolution: versionResolution)
-        let assetInfo = try await repositoryClient.fetchAssets(repositoryURL: url, version: version)
+        let assetInfo = try await assetRegistryClient.fetchAssets(repositoryURL: url, version: version)
         let selector = ArtifactBundleAssetSelector()
         guard let selectedAsset = selector.selectArtifactBundle(from: assetInfo.assets, fileName: repository.assetName) else {
             return Nestfile.Repository(

--- a/Sources/NestCLI/SwiftPackageBuilder.swift
+++ b/Sources/NestCLI/SwiftPackageBuilder.swift
@@ -7,7 +7,7 @@ public struct SwiftPackageBuilder {
     private let executorBuilder: any ProcessExecutorBuilder
     private let fileSystem: any FileSystem
     private let nestInfoController: NestInfoController
-    private let repositoryClientBuilder: GitRepositoryClientBuilder
+    private let assetRegistryClientBuilder: AssetRegistryClientBuilder
     private let logger: Logger
 
     public init(
@@ -15,14 +15,14 @@ public struct SwiftPackageBuilder {
         executorBuilder: any ProcessExecutorBuilder,
         fileSystem: some FileSystem,
         nestInfoController: NestInfoController,
-        repositoryClientBuilder: GitRepositoryClientBuilder,
+        assetRegistryClientBuilder: AssetRegistryClientBuilder,
         logger: Logger
     ) {
         self.workingDirectory = workingDirectory
         self.executorBuilder = executorBuilder
         self.fileSystem = fileSystem
         self.nestInfoController = nestInfoController
-        self.repositoryClientBuilder = repositoryClientBuilder
+        self.assetRegistryClientBuilder = assetRegistryClientBuilder
         self.logger = logger
     }
 
@@ -74,8 +74,8 @@ public struct SwiftPackageBuilder {
     private func resolveTagOrVersion(gitURL: GitURL, version: GitVersion) async throws -> String? {
         switch (gitURL, version) {
         case (.url(let url), .latestRelease):
-            let repositoryClient = repositoryClientBuilder.build(for: url)
-            return try? await repositoryClient.fetchAssets(repositoryURL: url, version: .latestRelease).tagName
+            let assetRegistryClient = assetRegistryClientBuilder.build(for: url)
+            return try? await assetRegistryClient.fetchAssets(repositoryURL: url, version: .latestRelease).tagName
 
         case (.ssh, .latestRelease):
             return nil

--- a/Sources/NestKit/Assets/AssetRegistryClient.swift
+++ b/Sources/NestKit/Assets/AssetRegistryClient.swift
@@ -1,6 +1,13 @@
 import Foundation
 
+/// A client that fetches information of assets which may contain an artifact bundle.
 public protocol AssetRegistryClient: Sendable {
+
+    /// Fetches information of assets in the repository which may contain an artifact bundle corresponding to the version
+    /// - Parameters:
+    ///   - repositoryURL: A url of a repository.
+    ///   - version: A version of asset you want.
+    /// - Returns: An asset information.
     func fetchAssets(repositoryURL: URL, version: GitVersion) async throws -> AssetInformation
 }
 
@@ -15,7 +22,10 @@ public struct AssetInformation: Sendable {
 }
 
 public struct Asset: Sendable, Equatable {
+    /// A file name of this asset.
     public var fileName: String
+
+    /// A url indicating a place of this asset.
     public var url: URL
 
     public init(fileName: String, url: URL) {

--- a/Sources/NestKit/Assets/AssetRegistryClient.swift
+++ b/Sources/NestKit/Assets/AssetRegistryClient.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol GitRepositoryClient: Sendable {
+public protocol AssetRegistryClient: Sendable {
     func fetchAssets(repositoryURL: URL, version: GitVersion) async throws -> AssetInformation
 }
 
@@ -26,7 +26,7 @@ public struct Asset: Sendable, Equatable {
 
 // MARK: - Errors
 
-public enum GitRepositoryClientError: LocalizedError, Hashable, Sendable {
+public enum AssetRegistryClientError: LocalizedError, Hashable, Sendable {
     case notFound
 
     public var errorDescription: String? {

--- a/Sources/NestKit/Assets/AssetRegistryClientBuilder.swift
+++ b/Sources/NestKit/Assets/AssetRegistryClientBuilder.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Logging
 
-public struct GitRepositoryClientBuilder: Sendable {
+public struct AssetRegistryClientBuilder: Sendable {
     private let httpClient: any HTTPClient
     private let authToken: String?
     private let logger: Logger
@@ -11,13 +11,19 @@ public struct GitRepositoryClientBuilder: Sendable {
         self.authToken = authToken
         self.logger = logger
     }
-
-    public func build(for url: GitURL) -> any GitRepositoryClient {
+    
+    /// Build AssetRegistryClient based on the given git url.
+    ///
+    /// > Note: This function currently supports only GitHub.
+    public func build(for url: GitURL) -> any AssetRegistryClient {
         // Only GitHub is supported now.
         GitHubRepositoryClient(httpClient: httpClient, authToken: authToken, logger: logger)
     }
 
-    public func build(for url: URL) -> any GitRepositoryClient {
+    /// Build AssetRegistryClient based on the given url.
+    ///
+    /// > Note: This function currently supports only GitHub.
+    public func build(for url: URL) -> any AssetRegistryClient {
         build(for: .url(url))
     }
 }

--- a/Sources/NestKit/Assets/AssetRegistryClientBuilder.swift
+++ b/Sources/NestKit/Assets/AssetRegistryClientBuilder.swift
@@ -17,7 +17,7 @@ public struct AssetRegistryClientBuilder: Sendable {
     /// > Note: This function currently supports only GitHub.
     public func build(for url: GitURL) -> any AssetRegistryClient {
         // Only GitHub is supported now.
-        GitHubRepositoryClient(httpClient: httpClient, authToken: authToken, logger: logger)
+        GitHubAssetRegistryClient(httpClient: httpClient, authToken: authToken, logger: logger)
     }
 
     /// Build AssetRegistryClient based on the given url.

--- a/Sources/NestKit/GitHub/GitHubRepositoryClient.swift
+++ b/Sources/NestKit/GitHub/GitHubRepositoryClient.swift
@@ -3,7 +3,7 @@ import HTTPTypes
 import HTTPTypesFoundation
 import Logging
 
-public struct GitHubRepositoryClient: GitRepositoryClient {
+public struct GitHubRepositoryClient: AssetRegistryClient {
     private let httpClient: any HTTPClient
     private let authToken: String?
     private let logger: Logger
@@ -32,7 +32,7 @@ public struct GitHubRepositoryClient: GitRepositoryClient {
         logger.debug("Status: \(response.status)")
 
         if response.status == .notFound {
-            throw GitRepositoryClientError.notFound
+            throw AssetRegistryClientError.notFound
         }
         let assetResponse = try JSONDecoder().decode(GitHubAssetResponse.self, from: data)
         let assets = assetResponse.assets.map { asset in

--- a/Sources/NestKit/GitHub/GitHubRepositoryClient.swift
+++ b/Sources/NestKit/GitHub/GitHubRepositoryClient.swift
@@ -3,7 +3,7 @@ import HTTPTypes
 import HTTPTypesFoundation
 import Logging
 
-public struct GitHubRepositoryClient: AssetRegistryClient {
+public struct GitHubAssetRegistryClient: AssetRegistryClient {
     private let httpClient: any HTTPClient
     private let authToken: String?
     private let logger: Logger

--- a/Sources/nest/Commands/ResolveNestfileCommand.swift
+++ b/Sources/nest/Commands/ResolveNestfileCommand.swift
@@ -34,7 +34,7 @@ extension ResolveNestfileCommand {
             logLevel: verbose ? .trace : .info
         )
         let controller = NestfileController(
-            repositoryClientBuilder: GitRepositoryClientBuilder(
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(
                 httpClient: configuration.httpClient,
                 authToken: ProcessInfo.processInfo.ghToken,
                 logger: configuration.logger

--- a/Sources/nest/Commands/UpdateNestfileCommand.swift
+++ b/Sources/nest/Commands/UpdateNestfileCommand.swift
@@ -34,7 +34,7 @@ extension UpdateNestfileCommand {
             logLevel: verbose ? .trace : .info
         )
         let controller = NestfileController(
-            repositoryClientBuilder: GitRepositoryClientBuilder(
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(
                 httpClient: configuration.httpClient,
                 authToken: ProcessInfo.processInfo.ghToken,
                 logger: configuration.logger

--- a/Sources/nest/Utils/Configuration+Dependencies.swift
+++ b/Sources/nest/Utils/Configuration+Dependencies.swift
@@ -21,7 +21,7 @@ extension Configuration {
             fileSystem: fileSystem,
             fileDownloader: NestFileDownloader(httpClient: httpClient),
             nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
-            repositoryClientBuilder: GitRepositoryClientBuilder(
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(
                 httpClient: httpClient,
                 authToken: ProcessInfo.processInfo.ghToken,
                 logger: logger
@@ -36,7 +36,7 @@ extension Configuration {
             executorBuilder: NestProcessExecutorBuilder(logger: logger),
             fileSystem: fileSystem,
             nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
-            repositoryClientBuilder: GitRepositoryClientBuilder(
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(
                 httpClient: httpClient,
                 authToken: ProcessInfo.processInfo.ghToken,
                 logger: logger

--- a/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
+++ b/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
@@ -45,7 +45,7 @@ struct ArtfactBundleFetcherTests {
             fileSystem: fileSystem,
             fileDownloader: fileDownloader,
             nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
-            repositoryClientBuilder: GitRepositoryClientBuilder(httpClient: httpClient, authToken: nil, logger: logger),
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, authToken: nil, logger: logger),
             logger: logger
         )
         let result = try await fetcher.downloadArtifactBundle(url: zipURL, checksum: .skip)
@@ -86,7 +86,7 @@ struct ArtfactBundleFetcherTests {
             fileSystem: fileSystem,
             fileDownloader: fileDownloader,
             nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
-            repositoryClientBuilder: GitRepositoryClientBuilder(httpClient: httpClient, authToken: nil, logger: logger),
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, authToken: nil, logger: logger),
             logger: logger
         )
         let gitRepositoryURL = try #require(URL(string: "https://github.com/owner/repo"))

--- a/Tests/NestCLITests/NestfileControllerTests.swift
+++ b/Tests/NestCLITests/NestfileControllerTests.swift
@@ -41,7 +41,7 @@ struct NestfileControllerTests {
         ]
 
         let controller = NestfileController(
-            repositoryClientBuilder: GitRepositoryClientBuilder(
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(
                 httpClient: httpClient,
                 authToken: nil,
                 logger: Logger(label: "Test")
@@ -93,7 +93,7 @@ struct NestfileControllerTests {
         ]
 
         let controller = NestfileController(
-            repositoryClientBuilder: GitRepositoryClientBuilder(
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(
                 httpClient: httpClient,
                 authToken: nil,
                 logger: Logger(label: "Test")

--- a/Tests/NestKitTests/GitHub/GitHubAssetRegistryClientTests.swift
+++ b/Tests/NestKitTests/GitHub/GitHubAssetRegistryClientTests.swift
@@ -4,7 +4,7 @@ import Foundation
 import HTTPTypes
 import Testing
 
-struct GitHubRepositoryClientTests {
+struct GitHubAssetRegistryClientTests {
     let fileSystem = MockFileSystem(
         homeDirectoryForCurrentUser: URL(filePath: "/User"),
         temporaryDirectory: URL(filePath: "/tmp")
@@ -33,12 +33,12 @@ struct GitHubRepositoryClientTests {
             """
             return (json.data(using: .utf8)!, HTTPResponse(status: .ok))
         }
-        let gitHubRepositoryClient: GitHubRepositoryClient = GitHubRepositoryClient(
+        let gitHubAssetRegistryClient = GitHubAssetRegistryClient(
             httpClient: httpClient,
             authToken: nil,
             logger: .init(label: "Test")
         )
-        let assets = try await gitHubRepositoryClient.fetchAssets(repositoryURL: repositoryURL, version: .tag("1.2.3"))
+        let assets = try await gitHubAssetRegistryClient.fetchAssets(repositoryURL: repositoryURL, version: .tag("1.2.3"))
         #expect(assets.assets == [Asset(fileName: "foo.zip", url: assetURL)])
     }
 }


### PR DESCRIPTION
close #26 

@giginet pointed out the original name is not matched with its responsibility.
It's reasonable,I followed his advice and I renamed `GitRepositoryClient` to `AssetRegistryClient` in this PR.