### PR TITLE
Add strict checksum validation paths for artifact bundle installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ targets:
   - reference: mtj0928/nest # or htpps://github.com/mtj0928/nest
     version: 0.1.0 # (Optional) When a version is not specified, the latest release will be used.
     assetName: nest-macos.artifactbundle.zip # (Optional) When a name is not specified, it will be resolved by GitHub API.
-    checksum: adcc2e3b4d48606cba7787153b0794f8a87e5289803466d63513f04c4d7661fb # Required for artifact bundle downloads. Run `update-nestfile` to populate.
+    checksum: adcc2e3b4d48606cba7787153b0794f8a87e5289803466d63513f04c4d7661fb # Recommended now and required in strict mode. Run `update-nestfile` to populate.
   # Example 2 Specify zip URL directly
   - zipURL: https://github.com/mtj0928/nest/releases/download/0.1.0/nest-macos.artifactbundle.zip
-    checksum: adcc2e3b4d48606cba7787153b0794f8a87e5289803466d63513f04c4d7661fb # Required for artifact bundle downloads.
+    checksum: adcc2e3b4d48606cba7787153b0794f8a87e5289803466d63513f04c4d7661fb # Recommended now and required in strict mode.
 registries:
   github:
     - host: my-github-enterprise.example.com
@@ -105,6 +105,10 @@ Run `update-nestfile` to populate the `checksum` fields, then run `bootstrap` to
 ```sh
 $ nest update-nestfile nestfile.yaml
 $ nest bootstrap nestfile.yaml
+
+# Opt in to the future strict behavior now.
+$ nest bootstrap nestfile.yaml --require-checksum
+$ NEST_REQUIRE_CHECKSUM=1 nest bootstrap nestfile.yaml
 
 # Pass --skip-checksum-validation to bypass verification (not recommended).
 $ nest bootstrap nestfile.yaml --skip-checksum-validation

--- a/README.md
+++ b/README.md
@@ -44,9 +44,17 @@ curl -s https://raw.githubusercontent.com/mtj0928/nest/main/Scripts/install.sh |
 
 ### Install packages
 ```sh
-$ nest install realm/SwiftLint 
+$ nest install realm/SwiftLint
 $ nest install realm/SwiftLint 0.55.0 # A version can be specified.
 $ nest install https://github.com/realm/SwiftLint 0.55.0
+
+# Verify the artifact bundle against a known checksum.
+$ nest install realm/SwiftLint 0.55.0 --checksum adcc2e3b...
+
+# When installing a direct artifact bundle URL, --checksum is required.
+# Use --allow-unverified to opt out of verification explicitly.
+$ nest install https://example.com/foo.artifactbundle.zip --checksum abc123...
+$ nest install https://example.com/foo.artifactbundle.zip --allow-unverified
 ```
 
 ### Uninstall package

--- a/README.md
+++ b/README.md
@@ -91,19 +91,23 @@ targets:
   - reference: mtj0928/nest # or htpps://github.com/mtj0928/nest
     version: 0.1.0 # (Optional) When a version is not specified, the latest release will be used.
     assetName: nest-macos.artifactbundle.zip # (Optional) When a name is not specified, it will be resolved by GitHub API.
-    checksum: adcc2e3b4d48606cba7787153b0794f8a87e5289803466d63513f04c4d7661fb # (Optional) This is recommended to add it.
+    checksum: adcc2e3b4d48606cba7787153b0794f8a87e5289803466d63513f04c4d7661fb # Required for artifact bundle downloads. Run `update-nestfile` to populate.
   # Example 2 Specify zip URL directly
   - zipURL: https://github.com/mtj0928/nest/releases/download/0.1.0/nest-macos.artifactbundle.zip
-    checksum: adcc2e3b4d48606cba7787153b0794f8a87e5289803466d63513f04c4d7661fb # (Optional) This is recommended to add it.
+    checksum: adcc2e3b4d48606cba7787153b0794f8a87e5289803466d63513f04c4d7661fb # Required for artifact bundle downloads.
 registries:
   github:
     - host: my-github-enterprise.example.com
       tokenEnvironmentVariable: "MY_GHE_TOKEN"
 ```
 
-Finally run `bootstrap` command. The command installs all artifact bundles in the nestfile at once.
+Run `update-nestfile` to populate the `checksum` fields, then run `bootstrap` to install all artifact bundles in the nestfile at once.
 ```sh
+$ nest update-nestfile nestfile.yaml
 $ nest bootstrap nestfile.yaml
+
+# Pass --skip-checksum-validation to bypass verification (not recommended).
+$ nest bootstrap nestfile.yaml --skip-checksum-validation
 ```
 
 ### Update nestfile

--- a/Sources/NestCLI/ArtifactBundleFetcher.swift
+++ b/Sources/NestCLI/ArtifactBundleFetcher.swift
@@ -158,6 +158,8 @@ public struct ArtifactBundleFetcher {
         try fileSystem.copyItem(at: downloadedFilePath, to: downloadedZipFilePath)
 
         switch checksum {
+        case .unresolvable(let error):
+            throw error
         case .needsCheck(let expectedChecksum):
             let calculatedChecksum = try await checksumCalculator.calculate(downloadedZipFilePath.path())
             if expectedChecksum != calculatedChecksum {
@@ -231,7 +233,11 @@ public enum ChecksumOption {
     case needsCheck(expected: String)
     case printActual(handler: (String) -> Void)
     case skip
-    
+    /// A configuration error that should surface only when an artifact bundle ZIP is actually
+    /// being downloaded. Build-from-source paths never consume the option, so the error is not
+    /// raised in those cases.
+    case unresolvable(ChecksumOptionError)
+
     public init(isSkip: Bool = false, expectedChecksum: String?, logger: Logger) {
         if isSkip {
             self = .skip
@@ -243,6 +249,17 @@ public enum ChecksumOption {
         }
         self = .printActual { checksum in
             logger.info("ℹ️ The checksum is \(checksum). Please add it to the nestfile to verify the downloaded file.")
+        }
+    }
+}
+
+public enum ChecksumOptionError: LocalizedError, Equatable, Sendable {
+    case mutuallyExclusiveFlags
+
+    public var errorDescription: String? {
+        switch self {
+        case .mutuallyExclusiveFlags:
+            "--checksum and --allow-unverified are mutually exclusive."
         }
     }
 }

--- a/Sources/NestCLI/ArtifactBundleFetcher.swift
+++ b/Sources/NestCLI/ArtifactBundleFetcher.swift
@@ -148,6 +148,11 @@ public struct ArtifactBundleFetcher {
     }
 
     private func downloadZIPFile(from url: URL, to destination: URL, checksum: ChecksumOption) async throws  {
+        // Surface unresolvable checksum configuration before spending bandwidth
+        // on a download whose archive we cannot accept anyway.
+        if url.needsUnzip, case .unresolvable(let error) = checksum {
+            throw error
+        }
         let downloadedFilePath = try await fileDownloader.download(url: url)
         if !url.needsUnzip {
             try fileSystem.copyItem(at: downloadedFilePath, to: destination)
@@ -255,11 +260,18 @@ public enum ChecksumOption {
 
 public enum ChecksumOptionError: LocalizedError, Equatable, Sendable {
     case mutuallyExclusiveFlags
+    case missingChecksum(target: String)
 
     public var errorDescription: String? {
         switch self {
         case .mutuallyExclusiveFlags:
             "--checksum and --allow-unverified are mutually exclusive."
+        case .missingChecksum(let target):
+            """
+            Missing checksum for "\(target)" in the nestfile.
+            Run `nest update-nestfile <path>` to populate checksums, \
+            or pass `--skip-checksum-validation` to bypass verification.
+            """
         }
     }
 }

--- a/Sources/NestCLI/ArtifactBundleFetcher.swift
+++ b/Sources/NestCLI/ArtifactBundleFetcher.swift
@@ -148,13 +148,16 @@ public struct ArtifactBundleFetcher {
     }
 
     private func downloadZIPFile(from url: URL, to destination: URL, checksum: ChecksumOption) async throws  {
-        // Surface unresolvable checksum configuration before spending bandwidth
-        // on a download whose archive we cannot accept anyway.
-        if url.needsUnzip, case .unresolvable(let error) = checksum {
-            throw error
+        // Surface checksum flag conflicts before spending bandwidth on a
+        // download whose archive we cannot accept anyway.
+        if url.needsUnzip, case .unresolvable(.mutuallyExclusiveFlags) = checksum {
+            throw ChecksumOptionError.mutuallyExclusiveFlags
         }
         let downloadedFilePath = try await fileDownloader.download(url: url)
         if !url.needsUnzip {
+            if case .unresolvable(let error) = checksum {
+                throw error
+            }
             try fileSystem.copyItem(at: downloadedFilePath, to: destination)
             return
         }
@@ -163,8 +166,35 @@ public struct ArtifactBundleFetcher {
         try fileSystem.copyItem(at: downloadedFilePath, to: downloadedZipFilePath)
 
         switch checksum {
-        case .unresolvable(let error):
-            throw error
+        case .unresolvable(.mutuallyExclusiveFlags):
+            throw ChecksumOptionError.mutuallyExclusiveFlags
+        case .unresolvable(.missingChecksum(let target)):
+            // TODO: Make missing checksums a hard error after the migration period ends.
+            // Keep this warning path only until existing CI users have had enough time
+            // to populate nestfile checksums with `nest update-nestfile`.
+            let calculatedChecksum = try await checksumCalculator.calculate(downloadedZipFilePath.path())
+            logger.warning(
+                """
+
+                🚨🚨🚨  CHECKSUM MISSING - UNVERIFIED ARTIFACT BUNDLE  🚨🚨🚨
+
+                nest is installing "\(target)" without checksum verification.
+                This is allowed temporarily for migration, but it will become an error in a future release.
+
+                Add this checksum to the target in your nestfile:
+                  checksum: \(calculatedChecksum)
+
+                Recommended:
+                  nest update-nestfile <path>
+
+                Temporary CI escape hatch:
+                  nest bootstrap <path> --skip-checksum-validation
+                  nest run --skip-checksum-validation ...
+
+                🚨🚨🚨  CHECKSUM MISSING - UNVERIFIED ARTIFACT BUNDLE  🚨🚨🚨
+                """,
+                metadata: .color(.yellow)
+            )
         case .needsCheck(let expectedChecksum):
             let calculatedChecksum = try await checksumCalculator.calculate(downloadedZipFilePath.path())
             if expectedChecksum != calculatedChecksum {

--- a/Sources/NestCLI/ArtifactBundleFetcher.swift
+++ b/Sources/NestCLI/ArtifactBundleFetcher.swift
@@ -157,8 +157,6 @@ public struct ArtifactBundleFetcher {
         try fileSystem.removeItemIfExists(at: downloadedZipFilePath)
         try fileSystem.copyItem(at: downloadedFilePath, to: downloadedZipFilePath)
 
-        try fileSystem.unzip(at: downloadedFilePath, to: destination)
-
         switch checksum {
         case .needsCheck(let expectedChecksum):
             let calculatedChecksum = try await checksumCalculator.calculate(downloadedZipFilePath.path())
@@ -174,6 +172,8 @@ public struct ArtifactBundleFetcher {
         case .skip:
             break
         }
+
+        try fileSystem.unzip(at: downloadedFilePath, to: destination)
     }
 }
 

--- a/Sources/NestCLI/ArtifactBundleFetcher.swift
+++ b/Sources/NestCLI/ArtifactBundleFetcher.swift
@@ -162,17 +162,12 @@ public struct ArtifactBundleFetcher {
         switch checksum {
         case .needsCheck(let expectedChecksum):
             let calculatedChecksum = try await checksumCalculator.calculate(downloadedZipFilePath.path())
-            if expectedChecksum == calculatedChecksum {
-                break
+            if expectedChecksum != calculatedChecksum {
+                throw ArtifactBundleFetcherError.checksumMismatch(
+                    expected: expectedChecksum,
+                    actual: calculatedChecksum
+                )
             }
-            logger.warning(
-                """
-                ⚠️ The checksum of the downloaded file does not match the expected checksum.
-                expected: \(expectedChecksum)
-                actual:   \(calculatedChecksum)
-                """,
-                metadata: .color(.yellow)
-            )
         case .printActual(let handler):
             let calculatedChecksum = try await checksumCalculator.calculate(downloadedZipFilePath.path())
             handler(calculatedChecksum)
@@ -209,12 +204,19 @@ public enum ArtifactBundleFetcherError: LocalizedError {
     case noCandidates
     case noTagSpecified
     case unsupportedTriple
+    case checksumMismatch(expected: String, actual: String)
 
     public var errorDescription: String? {
         switch self {
         case .noCandidates: "No candidates for artifact bundle in the repository, please specify the file name."
         case .noTagSpecified: "No tag specified, please specify the tag."
         case .unsupportedTriple: "No binaries corresponding to the current triple."
+        case .checksumMismatch(let expected, let actual):
+            """
+            The checksum of the downloaded file does not match the expected checksum.
+            expected: \(expected)
+            actual:   \(actual)
+            """
         }
     }
 }

--- a/Sources/NestCLI/ArtifactBundleFetcher.swift
+++ b/Sources/NestCLI/ArtifactBundleFetcher.swift
@@ -150,8 +150,8 @@ public struct ArtifactBundleFetcher {
     private func downloadZIPFile(from url: URL, to destination: URL, checksum: ChecksumOption) async throws  {
         // Surface checksum flag conflicts before spending bandwidth on a
         // download whose archive we cannot accept anyway.
-        if url.needsUnzip, case .unresolvable(.mutuallyExclusiveFlags) = checksum {
-            throw ChecksumOptionError.mutuallyExclusiveFlags
+        if url.needsUnzip, case .unresolvable(let error) = checksum {
+            throw error
         }
         let downloadedFilePath = try await fileDownloader.download(url: url)
         if !url.needsUnzip {
@@ -166,9 +166,9 @@ public struct ArtifactBundleFetcher {
         try fileSystem.copyItem(at: downloadedFilePath, to: downloadedZipFilePath)
 
         switch checksum {
-        case .unresolvable(.mutuallyExclusiveFlags):
-            throw ChecksumOptionError.mutuallyExclusiveFlags
-        case .unresolvable(.missingChecksum(let target)):
+        case .unresolvable(let error):
+            throw error
+        case .warnOnMissingChecksum(let target):
             // TODO: Make missing checksums a hard error after the migration period ends.
             // Keep this warning path only until existing CI users have had enough time
             // to populate nestfile checksums with `nest update-nestfile`.
@@ -268,6 +268,9 @@ public enum ChecksumOption {
     case needsCheck(expected: String)
     case printActual(handler: (String) -> Void)
     case skip
+    /// A temporary migration path for nestfiles without checksums. The archive is
+    /// accepted, but the actual checksum is printed prominently so users can pin it.
+    case warnOnMissingChecksum(target: String)
     /// A configuration error that should surface only when an artifact bundle ZIP is actually
     /// being downloaded. Build-from-source paths never consume the option, so the error is not
     /// raised in those cases.

--- a/Sources/NestCLI/ExecutableBinaryPreparer.swift
+++ b/Sources/NestCLI/ExecutableBinaryPreparer.swift
@@ -81,6 +81,8 @@ public struct ExecutableBinaryPreparer {
                 logger.info("🪺 The artifact bundle has been already installed.")
                 return resolveInstalledExecutableBinariesFromNestInfo(for: gitURL, version: version)
                     .map { PreparedBinary(executableBinary: $0, isAlreadyInstalled: true) }
+            } catch ArtifactBundleFetcherError.checksumMismatch(let expected, let actual) {
+                throw ArtifactBundleFetcherError.checksumMismatch(expected: expected, actual: actual)
             } catch {
                 logger.error(error)
             }

--- a/Sources/NestCLI/ExecutableBinaryPreparer.swift
+++ b/Sources/NestCLI/ExecutableBinaryPreparer.swift
@@ -83,6 +83,8 @@ public struct ExecutableBinaryPreparer {
                     .map { PreparedBinary(executableBinary: $0, isAlreadyInstalled: true) }
             } catch ArtifactBundleFetcherError.checksumMismatch(let expected, let actual) {
                 throw ArtifactBundleFetcherError.checksumMismatch(expected: expected, actual: actual)
+            } catch let error as ChecksumOptionError {
+                throw error
             } catch {
                 logger.error(error)
             }

--- a/Sources/NestCLI/Nestfile.swift
+++ b/Sources/NestCLI/Nestfile.swift
@@ -188,3 +188,15 @@ extension Nestfile.RegistryConfigs {
         github.reduce(into: [:]) { $0[$1.host] = $1.tokenEnvironmentVariable }
     }
 }
+
+extension Nestfile.Target {
+    package func checksumOption(skipValidation: Bool) -> ChecksumOption {
+        if skipValidation {
+            return .skip
+        }
+        if let checksum {
+            return .needsCheck(expected: checksum)
+        }
+        return .unresolvable(.missingChecksum(target: identifier))
+    }
+}

--- a/Sources/NestCLI/Nestfile.swift
+++ b/Sources/NestCLI/Nestfile.swift
@@ -72,6 +72,15 @@ public struct Nestfile: Codable, Sendable {
             case .deprecatedZIP: nil
             }
         }
+
+        /// A human-readable identifier used in log messages and error messages.
+        public var identifier: String {
+            switch self {
+            case .repository(let repository): repository.reference
+            case .zip(let zipURL): zipURL.zipURL
+            case .deprecatedZIP(let zipURL): zipURL.url
+            }
+        }
     }
 
     public struct Repository: Codable, Equatable, Sendable {

--- a/Sources/NestCLI/Nestfile.swift
+++ b/Sources/NestCLI/Nestfile.swift
@@ -115,7 +115,9 @@ public struct Nestfile: Codable, Sendable {
 
         public init(from decoder: any Decoder) throws {
             let container = try decoder.singleValueContainer()
-            self.url = try container.decode(String.self)
+            let url = try container.decode(String.self)
+            _ = try URL.httpsURL(from: url)
+            self.url = url
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -131,6 +133,14 @@ public struct Nestfile: Codable, Sendable {
         public init(zipURL: String, checksum: String?) {
             self.zipURL = zipURL
             self.checksum = checksum
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let zipURL = try container.decode(String.self, forKey: .zipURL)
+            _ = try URL.httpsURL(from: zipURL)
+            self.zipURL = zipURL
+            self.checksum = try container.decodeIfPresent(String.self, forKey: .checksum)
         }
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/NestCLI/Nestfile.swift
+++ b/Sources/NestCLI/Nestfile.swift
@@ -190,13 +190,17 @@ extension Nestfile.RegistryConfigs {
 }
 
 extension Nestfile.Target {
-    package func checksumOption(skipValidation: Bool) -> ChecksumOption {
+    // TODO: Remove `requireValidation` when checksum verification becomes the default behavior.
+    package func checksumOption(skipValidation: Bool, requireValidation: Bool = false) -> ChecksumOption {
         if skipValidation {
             return .skip
         }
         if let checksum {
             return .needsCheck(expected: checksum)
         }
-        return .unresolvable(.missingChecksum(target: identifier))
+        if requireValidation {
+            return .unresolvable(.missingChecksum(target: identifier))
+        }
+        return .warnOnMissingChecksum(target: identifier)
     }
 }

--- a/Sources/NestCLI/NestfileController.swift
+++ b/Sources/NestCLI/NestfileController.swift
@@ -32,18 +32,35 @@ public struct NestfileController: Sendable {
             }
     }
 
-    public func update(_ nestfile: Nestfile, excludedTargets: [ExcludedTarget]) async throws -> Nestfile {
+    public func update(
+        _ nestfile: Nestfile,
+        excludedTargets: [ExcludedTarget],
+        allowChecksumChanges: Bool = false
+    ) async throws -> Nestfile {
         var nestfile = nestfile
         nestfile.targets = try await nestfile.targets.asyncMap(numberOfConcurrentTasks: .max) { target in
-            try await updateTarget(target, versionResolution: .update, excludedTargets: excludedTargets)
+            try await updateTarget(
+                target,
+                versionResolution: .update,
+                excludedTargets: excludedTargets,
+                allowChecksumChanges: allowChecksumChanges
+            )
         }
         return nestfile
     }
 
-    public func resolve(_ nestfile: Nestfile) async throws -> Nestfile {
+    public func resolve(
+        _ nestfile: Nestfile,
+        allowChecksumChanges: Bool = false
+    ) async throws -> Nestfile {
         var nestfile = nestfile
         nestfile.targets = try await nestfile.targets.asyncMap(numberOfConcurrentTasks: .max) { target in
-            try await updateTarget(target, versionResolution: .specific, excludedTargets: [])
+            try await updateTarget(
+                target,
+                versionResolution: .specific,
+                excludedTargets: [],
+                allowChecksumChanges: allowChecksumChanges
+            )
         }
         return nestfile
     }
@@ -51,25 +68,35 @@ public struct NestfileController: Sendable {
     private func updateTarget(
         _ target: Nestfile.Target,
         versionResolution: VersionResolution,
-        excludedTargets: [ExcludedTarget]
+        excludedTargets: [ExcludedTarget],
+        allowChecksumChanges: Bool
     ) async throws -> Nestfile.Target {
         switch target {
         case .repository(let repository):
             let newRepository = try await updateRepository(
                 repository,
                 versionResolution: versionResolution,
-                excludedTargets: excludedTargets
+                excludedTargets: excludedTargets,
+                allowChecksumChanges: allowChecksumChanges
             )
             return .repository(newRepository)
         case .zip(let zipURL):
             guard let url = URL(string: zipURL.zipURL) else { return target }
-            let newZipURL = try await updateZip(url: url)
+            let newZipURL = try await updateZip(
+                url: url,
+                existingChecksum: zipURL.checksum,
+                allowChecksumChanges: allowChecksumChanges
+            )
             return .zip(newZipURL)
         case .deprecatedZIP(let zipURL):
             guard let url = URL(string: zipURL.url) else {
                 return .zip(Nestfile.ZIPURL(zipURL: zipURL.url, checksum: nil))
             }
-            let newZipURL = try await updateZip(url: url)
+            let newZipURL = try await updateZip(
+                url: url,
+                existingChecksum: nil,
+                allowChecksumChanges: allowChecksumChanges
+            )
             return .zip(newZipURL)
         }
     }
@@ -77,7 +104,8 @@ public struct NestfileController: Sendable {
     private func updateRepository(
         _ repository: Nestfile.Repository,
         versionResolution: VersionResolution,
-        excludedTargets: [ExcludedTarget]
+        excludedTargets: [ExcludedTarget],
+        allowChecksumChanges: Bool
     ) async throws -> Nestfile.Repository {
         let excludedTargetsMatchingReference = excludedTargets
             .filter { $0.reference == repository.reference }
@@ -122,6 +150,19 @@ public struct NestfileController: Sendable {
         }
 
         let checksum = try await downloadZIP(url: selectedAsset.url)
+        if !allowChecksumChanges,
+           let existingChecksum = repository.checksum,
+           let existingVersion = repository.version,
+           existingVersion == assetInfo.tagName,
+           let newChecksum = checksum,
+           existingChecksum != newChecksum {
+            throw NestfileControllerError.checksumChanged(
+                target: repository.reference,
+                version: existingVersion,
+                expected: existingChecksum,
+                actual: newChecksum
+            )
+        }
         return Nestfile.Repository(
             reference: repository.reference,
             version: assetInfo.tagName,
@@ -130,8 +171,23 @@ public struct NestfileController: Sendable {
         )
     }
 
-    private func updateZip(url: URL) async throws -> Nestfile.ZIPURL {
+    private func updateZip(
+        url: URL,
+        existingChecksum: String?,
+        allowChecksumChanges: Bool
+    ) async throws -> Nestfile.ZIPURL {
         let checksum = try await downloadZIP(url: url)
+        if !allowChecksumChanges,
+           let existingChecksum,
+           let newChecksum = checksum,
+           existingChecksum != newChecksum {
+            throw NestfileControllerError.checksumChanged(
+                target: url.absoluteString,
+                version: nil,
+                expected: existingChecksum,
+                actual: newChecksum
+            )
+        }
         return Nestfile.ZIPURL(zipURL: url.absoluteString, checksum: checksum)
     }
 
@@ -165,4 +221,22 @@ private enum VersionResolution {
     /// A case indicating using the latest version for repository whose version is not specified.
     /// If a version is specified, the versions is used.
     case specific
+}
+
+public enum NestfileControllerError: LocalizedError, Equatable, Sendable {
+    case checksumChanged(target: String, version: String?, expected: String, actual: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .checksumChanged(let target, let version, let expected, let actual):
+            let versionPart = version.map { " at version \($0)" } ?? ""
+            return """
+            Checksum changed for "\(target)"\(versionPart) without a version bump.
+            This may indicate a release re-tag, a compromised release, or a man-in-the-middle attack.
+            expected: \(expected)
+            actual:   \(actual)
+            If this change is expected, pass `--allow-checksum-changes` to overwrite.
+            """
+        }
+    }
 }

--- a/Sources/NestKit/Extensions/URL+extension.swift
+++ b/Sources/NestKit/Extensions/URL+extension.swift
@@ -10,7 +10,7 @@ extension URL {
         let repo = pathComponents[2].replacingOccurrences(of: ".\(pathExtension)", with: "")
         return "\(owner)/\(repo)"
     }
-    
+
     public var fileNameWithoutPathExtension: String {
         lastPathComponent.replacingOccurrences(of: ".\(pathExtension)", with: "")
     }
@@ -18,5 +18,40 @@ extension URL {
     public var needsUnzip: Bool {
         let utType = UTType(filenameExtension: pathExtension)
         return utType?.conforms(to: .zip) ?? false
+    }
+
+    /// Parses the given string and ensures it uses the HTTPS scheme.
+    ///
+    /// Use this for any URL that nest will fetch and execute downstream
+    /// (artifact bundle ZIPs and similar). Plain-text HTTP makes integrity
+    /// checks meaningless because a network attacker can swap both the
+    /// payload and any matching checksum metadata.
+    public static func httpsURL(from urlString: String) throws -> URL {
+        guard let url = URL(string: urlString) else {
+            throw URLValidationError.invalid(urlString)
+        }
+        guard url.scheme?.lowercased() == "https" else {
+            throw URLValidationError.insecureScheme(urlString)
+        }
+        return url
+    }
+}
+
+public enum URLValidationError: LocalizedError, Equatable, Sendable {
+    case invalid(String)
+    case insecureScheme(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalid(let urlString):
+            "Invalid URL: \(urlString)"
+        case .insecureScheme(let urlString):
+            """
+            Insecure URL "\(urlString)". \
+            nest only accepts HTTPS URLs for artifact bundle downloads, \
+            because plain-text HTTP allows a network attacker to swap both \
+            the payload and the checksum.
+            """
+        }
     }
 }

--- a/Sources/nest/Commands/BootstrapCommand.swift
+++ b/Sources/nest/Commands/BootstrapCommand.swift
@@ -34,7 +34,14 @@ struct BootstrapCommand: AsyncParsableCommand {
         for targetInfo in nestfile.targets {
             let target: InstallTarget
             var version: GitVersion
-            let checksumOption = ChecksumOption(isSkip: skipChecksumValidation, expectedChecksum: targetInfo.checksum, logger: logger)
+            let checksumOption: ChecksumOption =
+                if skipChecksumValidation {
+                    .skip
+                } else if let expected = targetInfo.checksum {
+                    .needsCheck(expected: expected)
+                } else {
+                    .unresolvable(.missingChecksum(target: targetInfo.identifier))
+                }
 
             switch (targetInfo.resolveInstallTarget(), targetInfo.resolveVersion()) {
             case (.failure(let error), _):

--- a/Sources/nest/Commands/BootstrapCommand.swift
+++ b/Sources/nest/Commands/BootstrapCommand.swift
@@ -1,8 +1,8 @@
 import ArgumentParser
 import Foundation
+import Logging
 import NestCLI
 import NestKit
-import Logging
 
 struct BootstrapCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -16,12 +16,17 @@ struct BootstrapCommand: AsyncParsableCommand {
     @Flag(name: .shortAndLong, help: "Skip checksum validation for downloaded artifactbundles.")
     var skipChecksumValidation = false
 
+    // TODO: Remove this opt-in flag when checksum verification becomes the default behavior.
+    @Flag(help: "Require checksums for downloaded artifact bundles.")
+    var requireChecksum = false
+
     @Flag(name: .shortAndLong)
     var verbose: Bool = false
 
     mutating func run() async throws {
         let nestfile = try Nestfile.load(from: nestfilePath, fileSystem: FileManager.default)
         let (executableBinaryPreparer, artifactBundleManager, logger) = setUp(nestfile: nestfile)
+        let requireChecksum = requireChecksum || ProcessInfo.processInfo.requireChecksum
 
         if nestfile.targets.contains(where: { $0.isDeprecatedZIP }) {
             logger.warning("""
@@ -34,7 +39,7 @@ struct BootstrapCommand: AsyncParsableCommand {
         for targetInfo in nestfile.targets {
             let target: InstallTarget
             var version: GitVersion
-            let checksumOption = targetInfo.checksumOption(skipValidation: skipChecksumValidation)
+            let checksumOption = targetInfo.checksumOption(skipValidation: skipChecksumValidation, requireValidation: requireChecksum)
 
             switch (targetInfo.resolveInstallTarget(), targetInfo.resolveVersion()) {
             case (.failure(let error), _):

--- a/Sources/nest/Commands/BootstrapCommand.swift
+++ b/Sources/nest/Commands/BootstrapCommand.swift
@@ -34,14 +34,7 @@ struct BootstrapCommand: AsyncParsableCommand {
         for targetInfo in nestfile.targets {
             let target: InstallTarget
             var version: GitVersion
-            let checksumOption: ChecksumOption =
-                if skipChecksumValidation {
-                    .skip
-                } else if let expected = targetInfo.checksum {
-                    .needsCheck(expected: expected)
-                } else {
-                    .unresolvable(.missingChecksum(target: targetInfo.identifier))
-                }
+            let checksumOption = targetInfo.checksumOption(skipValidation: skipChecksumValidation)
 
             switch (targetInfo.resolveInstallTarget(), targetInfo.resolveVersion()) {
             case (.failure(let error), _):

--- a/Sources/nest/Commands/InstallCommand.swift
+++ b/Sources/nest/Commands/InstallCommand.swift
@@ -1,8 +1,8 @@
 import ArgumentParser
 import Foundation
+import Logging
 import NestCLI
 import NestKit
-import Logging
 
 struct InstallCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -23,6 +23,10 @@ struct InstallCommand: AsyncParsableCommand {
 
     @Flag(help: "Skip checksum verification. Required when installing a direct artifact bundle URL without --checksum.")
     var allowUnverified = false
+
+    // TODO: Remove this opt-in flag when checksum verification becomes the default behavior.
+    @Flag(help: "Require checksum for downloaded artifact bundles.")
+    var requireChecksum = false
 
     @Flag(name: .shortAndLong)
     var verbose: Bool = false
@@ -51,6 +55,8 @@ struct InstallCommand: AsyncParsableCommand {
             let checksumOption: ChecksumOption =
                 if checksum != nil && allowUnverified {
                     .unresolvable(.mutuallyExclusiveFlags)
+                } else if checksum == nil && !allowUnverified && (requireChecksum || ProcessInfo.processInfo.requireChecksum) {
+                    .unresolvable(.missingChecksum(target: target.identifier))
                 } else {
                     ChecksumOption(
                         isSkip: allowUnverified,
@@ -90,6 +96,17 @@ struct InstallCommand: AsyncParsableCommand {
         } catch {
             logger.error(error)
             Foundation.exit(1)
+        }
+    }
+}
+
+extension InstallTarget {
+    var identifier: String {
+        switch self {
+        case .git(let gitURL):
+            gitURL.reference ?? gitURL.stringURL
+        case .artifactBundle(let url):
+            url.absoluteString
         }
     }
 }

--- a/Sources/nest/Commands/InstallCommand.swift
+++ b/Sources/nest/Commands/InstallCommand.swift
@@ -18,12 +18,38 @@ struct InstallCommand: AsyncParsableCommand {
     @Argument
     var version: GitVersion = .latestRelease
 
+    @Option(help: "Verify the downloaded artifact bundle against this checksum.")
+    var checksum: String?
+
+    @Flag(help: "Skip checksum verification. Required when installing a direct artifact bundle URL without --checksum.")
+    var allowUnverified = false
+
     @Flag(name: .shortAndLong)
     var verbose: Bool = false
 
     mutating func run() async throws {
         let (executableBinaryPreparer, nestDirectory, artifactBundleManager, logger) = setUp()
         do {
+            if checksum != nil && allowUnverified {
+                logger.error("--checksum and --allow-unverified are mutually exclusive.", metadata: .color(.red))
+                Foundation.exit(1)
+            }
+            if case .artifactBundle = target, checksum == nil, !allowUnverified {
+                logger.error(
+                    """
+                    Installing a direct artifact bundle URL requires integrity verification.
+                    Pass --checksum <value> to verify, or --allow-unverified to skip explicitly.
+                    """,
+                    metadata: .color(.red)
+                )
+                Foundation.exit(1)
+            }
+
+            let checksumOption = ChecksumOption(
+                isSkip: allowUnverified,
+                expectedChecksum: checksum,
+                logger: logger
+            )
 
             let executableBinaries: [PreparedBinary] = switch target {
             case .git(let gitURL):
@@ -31,10 +57,10 @@ struct InstallCommand: AsyncParsableCommand {
                     at: gitURL,
                     version: version,
                     artifactBundleZipFileName: nil,
-                    checksum: .skip
+                    checksum: checksumOption
                 )
             case .artifactBundle(let url):
-                try await executableBinaryPreparer.fetchArtifactBundle(at: url, checksum: .skip)
+                try await executableBinaryPreparer.fetchArtifactBundle(at: url, checksum: checksumOption)
             }
 
             for binary in executableBinaries {

--- a/Sources/nest/Commands/InstallCommand.swift
+++ b/Sources/nest/Commands/InstallCommand.swift
@@ -30,10 +30,10 @@ struct InstallCommand: AsyncParsableCommand {
     mutating func run() async throws {
         let (executableBinaryPreparer, nestDirectory, artifactBundleManager, logger) = setUp()
         do {
-            if checksum != nil && allowUnverified {
-                logger.error("--checksum and --allow-unverified are mutually exclusive.", metadata: .color(.red))
-                Foundation.exit(1)
-            }
+            // Direct artifact bundle URLs always download a ZIP, so the user must
+            // make a verification decision up front. The git path may build from
+            // source instead, so any checksum-flag inconsistency is deferred to
+            // `.unresolvable` and only surfaces if a ZIP is actually downloaded.
             if case .artifactBundle = target, checksum == nil, !allowUnverified {
                 logger.error(
                     """
@@ -45,11 +45,16 @@ struct InstallCommand: AsyncParsableCommand {
                 Foundation.exit(1)
             }
 
-            let checksumOption = ChecksumOption(
-                isSkip: allowUnverified,
-                expectedChecksum: checksum,
-                logger: logger
-            )
+            let checksumOption: ChecksumOption =
+                if checksum != nil && allowUnverified {
+                    .unresolvable(.mutuallyExclusiveFlags)
+                } else {
+                    ChecksumOption(
+                        isSkip: allowUnverified,
+                        expectedChecksum: checksum,
+                        logger: logger
+                    )
+                }
 
             let executableBinaries: [PreparedBinary] = switch target {
             case .git(let gitURL):

--- a/Sources/nest/Commands/InstallCommand.swift
+++ b/Sources/nest/Commands/InstallCommand.swift
@@ -34,15 +34,18 @@ struct InstallCommand: AsyncParsableCommand {
             // make a verification decision up front. The git path may build from
             // source instead, so any checksum-flag inconsistency is deferred to
             // `.unresolvable` and only surfaces if a ZIP is actually downloaded.
-            if case .artifactBundle = target, checksum == nil, !allowUnverified {
-                logger.error(
-                    """
-                    Installing a direct artifact bundle URL requires integrity verification.
-                    Pass --checksum <value> to verify, or --allow-unverified to skip explicitly.
-                    """,
-                    metadata: .color(.red)
-                )
-                Foundation.exit(1)
+            if case .artifactBundle(let url) = target {
+                _ = try URL.httpsURL(from: url.absoluteString)
+                if checksum == nil, !allowUnverified {
+                    logger.error(
+                        """
+                        Installing a direct artifact bundle URL requires integrity verification.
+                        Pass --checksum <value> to verify, or --allow-unverified to skip explicitly.
+                        """,
+                        metadata: .color(.red)
+                    )
+                    Foundation.exit(1)
+                }
             }
 
             let checksumOption: ChecksumOption =

--- a/Sources/nest/Commands/ResolveNestfileCommand.swift
+++ b/Sources/nest/Commands/ResolveNestfileCommand.swift
@@ -14,13 +14,16 @@ struct ResolveNestfileCommand: AsyncParsableCommand {
     @Argument(help: "A nestfile written in yaml.")
     var nestfilePath: String
 
+    @Flag(help: "Overwrite the existing checksum even when the target version is unchanged. Use this only when a release was legitimately re-tagged.")
+    var allowChecksumChanges: Bool = false
+
     @Flag(name: .shortAndLong)
     var verbose: Bool = false
 
     mutating func run() async throws {
         let nestfile = try Nestfile.load(from: nestfilePath, fileSystem: FileManager.default)
         let (controller, fileSystem, logger) = setUp(nestfile: nestfile)
-        let updatedNestfile = try await controller.resolve(nestfile)
+        let updatedNestfile = try await controller.resolve(nestfile, allowChecksumChanges: allowChecksumChanges)
         try updatedNestfile.write(to: nestfilePath, fileSystem: fileSystem)
         logger.info("✨ \(URL(filePath: nestfilePath).lastPathComponent) is Updated")
     }

--- a/Sources/nest/Commands/RunCommand.swift
+++ b/Sources/nest/Commands/RunCommand.swift
@@ -18,6 +18,10 @@ struct RunCommand: AsyncParsableCommand {
 
     @Flag(name: .shortAndLong, help: "Skip checksum validation for downloaded artifactbundles.")
     var skipChecksumValidation = false
+
+    // TODO: Remove this opt-in flag when checksum verification becomes the default behavior.
+    @Flag(help: "Require checksums for downloaded artifact bundles.")
+    var requireChecksum = false
     
     @Option(help: "A path to nestfile", completion: .file(extensions: ["yaml"]))
     var nestfilePath = "nestfile.yaml"
@@ -64,6 +68,7 @@ struct RunCommand: AsyncParsableCommand {
 
         let version = GitVersion.tag(expectedVersion)
         let executables: [ExecutableBinary]
+        let requireChecksum = requireChecksum || ProcessInfo.processInfo.requireChecksum
         let installedBinaries = executableBinaryPreparer.resolveInstalledExecutableBinariesFromNestInfo(for: subcommand.repository, version: version)
         if !installedBinaries.isEmpty {
             executables = installedBinaries
@@ -76,7 +81,7 @@ struct RunCommand: AsyncParsableCommand {
                 gitURL: subcommand.repository,
                 version: version,
                 assetName: target.assetName,
-                checksumOption: target.checksumOption(skipValidation: skipChecksumValidation)
+                checksumOption: target.checksumOption(skipValidation: skipChecksumValidation, requireValidation: requireChecksum)
             )
             executables = executableBinaryPreparer.resolveInstalledExecutableBinariesFromNestInfo(for: subcommand.repository, version: version)
         }

--- a/Sources/nest/Commands/RunCommand.swift
+++ b/Sources/nest/Commands/RunCommand.swift
@@ -1,8 +1,8 @@
 import ArgumentParser
 import Foundation
-import NestKit
-import NestCLI
 import Logging
+import NestCLI
+import NestKit
 
 struct RunCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -15,6 +15,9 @@ struct RunCommand: AsyncParsableCommand {
     
     @Flag(help: "Will not perform installation.")
     var noInstall = false
+
+    @Flag(name: .shortAndLong, help: "Skip checksum validation for downloaded artifactbundles.")
+    var skipChecksumValidation = false
     
     @Option(help: "A path to nestfile", completion: .file(extensions: ["yaml"]))
     var nestfilePath = "nestfile.yaml"
@@ -37,7 +40,7 @@ struct RunCommand: AsyncParsableCommand {
             return
         }
 
-        let (nestfileController, executableBinaryPreparer, nestDirectory, logger) = setUp(nestfile: nestfile)
+        let (nestfileController, executableBinaryPreparer, _, logger) = setUp(nestfile: nestfile)
 
         let subcommand: SubCommandOfRunCommand
         do {
@@ -73,7 +76,7 @@ struct RunCommand: AsyncParsableCommand {
                 gitURL: subcommand.repository,
                 version: version,
                 assetName: target.assetName,
-                checksumOption: ChecksumOption(expectedChecksum: target.checksum, logger: logger)
+                checksumOption: target.checksumOption(skipValidation: skipChecksumValidation)
             )
             executables = executableBinaryPreparer.resolveInstalledExecutableBinariesFromNestInfo(for: subcommand.repository, version: version)
         }

--- a/Sources/nest/Commands/UpdateNestfileCommand.swift
+++ b/Sources/nest/Commands/UpdateNestfileCommand.swift
@@ -17,13 +17,20 @@ struct UpdateNestfileCommand: AsyncParsableCommand {
     @Option(parsing: .upToNextOption, help: "Exclude by repository or version when using reference-only.\n(ex. --excludes owner/repo@0.0.1 owner/repo@0.0.2)")
     var excludes: [ExcludedTarget] = []
 
+    @Flag(help: "Overwrite the existing checksum even when the target version is unchanged. Use this only when a release was legitimately re-tagged.")
+    var allowChecksumChanges: Bool = false
+
     @Flag(name: .shortAndLong)
     var verbose: Bool = false
 
     mutating func run() async throws {
         let nestfile = try Nestfile.load(from: nestfilePath, fileSystem: FileManager.default)
         let (controller, fileSystem, logger) = setUp(nestfile: nestfile)
-        let updatedNestfile = try await controller.update(nestfile, excludedTargets: excludes)
+        let updatedNestfile = try await controller.update(
+            nestfile,
+            excludedTargets: excludes,
+            allowChecksumChanges: allowChecksumChanges
+        )
         try updatedNestfile.write(to: nestfilePath, fileSystem: fileSystem)
         logger.info("✨ \(URL(filePath: nestfilePath).lastPathComponent) is Updated")
     }

--- a/Sources/nest/nest.swift
+++ b/Sources/nest/nest.swift
@@ -1,8 +1,8 @@
 import ArgumentParser
 import Foundation
-import NestKit
-import NestCLI
 import Logging
+import NestCLI
+import NestKit
 
 @main
 struct Nest: AsyncParsableCommand {
@@ -68,5 +68,15 @@ extension FileSystem {
 extension ProcessInfo {
     var nestPath: String? {
         environment["NEST_PATH"]
+    }
+
+    // TODO: Remove this opt-in environment variable when checksum verification becomes the default behavior.
+    var requireChecksum: Bool {
+        switch environment["NEST_REQUIRE_CHECKSUM"]?.lowercased() {
+        case "1", "true", "yes", "on":
+            true
+        default:
+            false
+        }
     }
 }

--- a/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
+++ b/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
@@ -60,6 +60,32 @@ struct ArtfactBundleFetcherTests {
         )])
     }
 
+    @Test
+    func downloadArtifactBundleThrowsOnChecksumMismatch() async throws {
+        let workingDirectory = URL(filePath: "/tmp/nest")
+        let zipURL = try #require(URL(string: "https://example.com/artifactbundle.zip"))
+        let httpClient = MockHTTPClient(mockFileSystem: fileSystem)
+        httpClient.dummyData = [zipURL: try Data(contentsOf: artifactBundlePath)]
+
+        let fileDownloader = NestFileDownloader(httpClient: httpClient)
+        let fetcher = ArtifactBundleFetcher(
+            workingDirectory: workingDirectory,
+            executorBuilder: executorBuilder,
+            fileSystem: fileSystem,
+            fileDownloader: fileDownloader,
+            nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            logger: logger
+        )
+
+        await #expect(throws: ArtifactBundleFetcherError.self) {
+            try await fetcher.downloadArtifactBundle(
+                url: zipURL,
+                checksum: .needsCheck(expected: "different-checksum")
+            )
+        }
+    }
+
     @Test(arguments: [
         (artifactBundlePath: artifactBundlePath, expectedBinaryPath: URL(filePath: "/tmp/nest/repo/foo.artifactbundle/foo-1.0.0-macosx/bin/foo")),
         (artifactBundlePath: withoutArtifactBundleFolderPath, expectedBinaryPath: URL(filePath: "/tmp/nest/repo/foo-1.0.0-macosx/bin/foo"))

--- a/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
+++ b/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
@@ -137,7 +137,7 @@ struct ArtfactBundleFetcherTests {
 
         let result = try await fetcher.downloadArtifactBundle(
             url: zipURL,
-            checksum: .unresolvable(.missingChecksum(target: "owner/repo"))
+            checksum: .warnOnMissingChecksum(target: "owner/repo")
         )
 
         #expect(result == [ExecutableBinary(
@@ -146,6 +146,32 @@ struct ArtfactBundleFetcherTests {
             version: "1.0.0",
             manufacturer: .artifactBundle(sourceInfo: ArtifactBundleSourceInfo(zipURL: zipURL, repository: nil))
         )])
+    }
+
+    @Test
+    func missingChecksumThrowsOnZipDownloadInStrictMode() async throws {
+        let workingDirectory = URL(filePath: "/tmp/nest")
+        let zipURL = try #require(URL(string: "https://example.com/artifactbundle.zip"))
+        let httpClient = MockHTTPClient(mockFileSystem: fileSystem)
+        httpClient.dummyData = [zipURL: try Data(contentsOf: artifactBundlePath)]
+
+        let fileDownloader = NestFileDownloader(httpClient: httpClient)
+        let fetcher = ArtifactBundleFetcher(
+            workingDirectory: workingDirectory,
+            executorBuilder: executorBuilder,
+            fileSystem: fileSystem,
+            fileDownloader: fileDownloader,
+            nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            logger: logger
+        )
+
+        await #expect(throws: ChecksumOptionError.missingChecksum(target: "owner/repo")) {
+            try await fetcher.downloadArtifactBundle(
+                url: zipURL,
+                checksum: .unresolvable(.missingChecksum(target: "owner/repo"))
+            )
+        }
     }
 
     @Test(arguments: [

--- a/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
+++ b/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
@@ -91,6 +91,32 @@ struct ArtfactBundleFetcherTests {
         #expect(!fileSystem.fileExists(atPath: destination.path()))
     }
 
+    @Test
+    func unresolvableChecksumThrowsOnZipDownload() async throws {
+        let workingDirectory = URL(filePath: "/tmp/nest")
+        let zipURL = try #require(URL(string: "https://example.com/artifactbundle.zip"))
+        let httpClient = MockHTTPClient(mockFileSystem: fileSystem)
+        httpClient.dummyData = [zipURL: try Data(contentsOf: artifactBundlePath)]
+
+        let fileDownloader = NestFileDownloader(httpClient: httpClient)
+        let fetcher = ArtifactBundleFetcher(
+            workingDirectory: workingDirectory,
+            executorBuilder: executorBuilder,
+            fileSystem: fileSystem,
+            fileDownloader: fileDownloader,
+            nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            logger: logger
+        )
+
+        await #expect(throws: ChecksumOptionError.mutuallyExclusiveFlags) {
+            try await fetcher.downloadArtifactBundle(
+                url: zipURL,
+                checksum: .unresolvable(.mutuallyExclusiveFlags)
+            )
+        }
+    }
+
     @Test(arguments: [
         (artifactBundlePath: artifactBundlePath, expectedBinaryPath: URL(filePath: "/tmp/nest/repo/foo.artifactbundle/foo-1.0.0-macosx/bin/foo")),
         (artifactBundlePath: withoutArtifactBundleFolderPath, expectedBinaryPath: URL(filePath: "/tmp/nest/repo/foo-1.0.0-macosx/bin/foo"))

--- a/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
+++ b/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
@@ -84,6 +84,11 @@ struct ArtfactBundleFetcherTests {
                 checksum: .needsCheck(expected: "different-checksum")
             )
         }
+
+        // The destination directory must not be populated when the checksum
+        // verification fails: unzip must not run before verification.
+        let destination = workingDirectory.appending(component: zipURL.fileNameWithoutPathExtension)
+        #expect(!fileSystem.fileExists(atPath: destination.path()))
     }
 
     @Test(arguments: [

--- a/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
+++ b/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
@@ -117,6 +117,37 @@ struct ArtfactBundleFetcherTests {
         }
     }
 
+    @Test
+    func missingChecksumContinuesZipDownloadForMigration() async throws {
+        let workingDirectory = URL(filePath: "/tmp/nest")
+        let zipURL = try #require(URL(string: "https://example.com/artifactbundle.zip"))
+        let httpClient = MockHTTPClient(mockFileSystem: fileSystem)
+        httpClient.dummyData = [zipURL: try Data(contentsOf: artifactBundlePath)]
+
+        let fileDownloader = NestFileDownloader(httpClient: httpClient)
+        let fetcher = ArtifactBundleFetcher(
+            workingDirectory: workingDirectory,
+            executorBuilder: executorBuilder,
+            fileSystem: fileSystem,
+            fileDownloader: fileDownloader,
+            nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            logger: logger
+        )
+
+        let result = try await fetcher.downloadArtifactBundle(
+            url: zipURL,
+            checksum: .unresolvable(.missingChecksum(target: "owner/repo"))
+        )
+
+        #expect(result == [ExecutableBinary(
+            commandName: "foo",
+            binaryPath: URL(filePath: "/tmp/nest/artifactbundle/foo.artifactbundle/foo-1.0.0-macosx/bin/foo"),
+            version: "1.0.0",
+            manufacturer: .artifactBundle(sourceInfo: ArtifactBundleSourceInfo(zipURL: zipURL, repository: nil))
+        )])
+    }
+
     @Test(arguments: [
         (artifactBundlePath: artifactBundlePath, expectedBinaryPath: URL(filePath: "/tmp/nest/repo/foo.artifactbundle/foo-1.0.0-macosx/bin/foo")),
         (artifactBundlePath: withoutArtifactBundleFolderPath, expectedBinaryPath: URL(filePath: "/tmp/nest/repo/foo-1.0.0-macosx/bin/foo"))

--- a/Tests/NestCLITests/NestfileControllerTests.swift
+++ b/Tests/NestCLITests/NestfileControllerTests.swift
@@ -159,6 +159,49 @@ struct NestfileControllerTests {
     }
 
     @Test
+    func resolveDetectsChecksumChangeForSameVersion() async throws {
+        let zipFileURL = try #require(URL(string: "https://example.com/foo.artifacatbundle.zip"))
+        let barReleaseURL = try #require(URL(string: "https://api.github.com/repos/foo/bar/releases/tags/0.0.1"))
+        let assetResponse = GitHubAssetResponse(
+            assets: [GitHubAsset(name: "foo.artifactbundle.zip", browserDownloadURL: zipFileURL)],
+            tagName: "0.0.1"
+        )
+        httpClient.dummyData = try [
+            barReleaseURL: JSONEncoder().encode(assetResponse),
+            zipFileURL: Data(contentsOf: artifactBundlePath)
+        ]
+
+        let controller = NestfileController(
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(
+                httpClient: httpClient,
+                registryConfigs: nil,
+                logger: Logger(label: "Test")
+            ),
+            fileSystem: fileSystem,
+            fileDownloader: NestFileDownloader(httpClient: httpClient),
+            checksumCalculator: SwiftChecksumCalculator(processExecutor: processExecutor)
+        )
+        // The existing checksum "stale-checksum" differs from the freshly computed "aaa".
+        // resolve should refuse to silently overwrite when the version did not change.
+        let nestfile = Nestfile(nestPath: "./.nest", targets: [
+            .repository(Nestfile.Repository(
+                reference: "foo/bar",
+                version: "0.0.1",
+                assetName: "foo.artifactbundle.zip",
+                checksum: "stale-checksum"
+            )),
+        ])
+
+        await #expect(throws: NestfileControllerError.self) {
+            try await controller.resolve(nestfile)
+        }
+
+        // When opted in via allowChecksumChanges, the checksum is overwritten.
+        let overwritten = try await controller.resolve(nestfile, allowChecksumChanges: true)
+        #expect(overwritten.targets[0].checksum == "aaa")
+    }
+
+    @Test
     func resolve() async throws {
         let zipFileURL = try #require(URL(string: "https://example.com/foo.artifacatbundle.zip"))
         let barReleaseURL = try #require(URL(string: "https://api.github.com/repos/foo/bar/releases/tags/0.0.1"))

--- a/Tests/NestCLITests/NestfileTargetChecksumOptionTests.swift
+++ b/Tests/NestCLITests/NestfileTargetChecksumOptionTests.swift
@@ -19,6 +19,18 @@ struct NestfileTargetChecksumOptionTests {
         let target = Nestfile.Target.repository(Nestfile.Repository(reference: "owner/repo", version: "1.0.0", assetName: nil, checksum: nil))
 
         switch target.checksumOption(skipValidation: false) {
+        case .warnOnMissingChecksum(let targetIdentifier):
+            #expect(targetIdentifier == "owner/repo")
+        default:
+            Issue.record("Expected .warnOnMissingChecksum")
+        }
+    }
+
+    @Test
+    func checksumOptionIsUnresolvableWhenChecksumIsMissingInStrictMode() {
+        let target = Nestfile.Target.repository(Nestfile.Repository(reference: "owner/repo", version: "1.0.0", assetName: nil, checksum: nil))
+
+        switch target.checksumOption(skipValidation: false, requireValidation: true) {
         case .unresolvable(.missingChecksum(let targetIdentifier)):
             #expect(targetIdentifier == "owner/repo")
         default:

--- a/Tests/NestCLITests/NestfileTargetChecksumOptionTests.swift
+++ b/Tests/NestCLITests/NestfileTargetChecksumOptionTests.swift
@@ -1,0 +1,40 @@
+import NestCLI
+import Testing
+
+struct NestfileTargetChecksumOptionTests {
+    @Test
+    func checksumOptionNeedsCheckWhenChecksumExists() {
+        let target = Nestfile.Target.repository(Nestfile.Repository(reference: "owner/repo", version: "1.0.0", assetName: nil, checksum: "abc123"))
+
+        switch target.checksumOption(skipValidation: false) {
+        case .needsCheck(let expected):
+            #expect(expected == "abc123")
+        default:
+            Issue.record("Expected .needsCheck")
+        }
+    }
+
+    @Test
+    func checksumOptionIsUnresolvableWhenChecksumIsMissing() {
+        let target = Nestfile.Target.repository(Nestfile.Repository(reference: "owner/repo", version: "1.0.0", assetName: nil, checksum: nil))
+
+        switch target.checksumOption(skipValidation: false) {
+        case .unresolvable(.missingChecksum(let targetIdentifier)):
+            #expect(targetIdentifier == "owner/repo")
+        default:
+            Issue.record("Expected .unresolvable(.missingChecksum)")
+        }
+    }
+
+    @Test
+    func checksumOptionSkipsWhenValidationIsSkipped() {
+        let target = Nestfile.Target.repository(Nestfile.Repository(reference: "owner/repo", version: "1.0.0", assetName: nil, checksum: nil))
+
+        switch target.checksumOption(skipValidation: true) {
+        case .skip:
+            break
+        default:
+            Issue.record("Expected .skip")
+        }
+    }
+}

--- a/Tests/NestCLITests/NestfileTests.swift
+++ b/Tests/NestCLITests/NestfileTests.swift
@@ -99,4 +99,48 @@ struct NestfileTests {
     func targetIdentifier(target: Nestfile.Target, expected: String) {
         #expect(target.identifier == expected)
     }
+
+    @Test
+    func loadFileRejectsHTTPZIPURL() throws {
+        let nestFile = """
+        nestPath: "aaa"
+        targets:
+          - zipURL: http://example.com/foo.zip
+        """
+
+        fileSystem.item = [
+            "/": [
+                "User": .directory,
+                "tmp": .directory
+            ]
+        ]
+        let nestFilePath = URL(filePath: "/User/nestfile")
+        try fileSystem.write(nestFile.data(using: .utf8)!, to: nestFilePath)
+
+        #expect(throws: (any Error).self) {
+            try Nestfile.load(from: nestFilePath.path(), fileSystem: fileSystem)
+        }
+    }
+
+    @Test
+    func loadFileRejectsHTTPDeprecatedZIPURL() throws {
+        let nestFile = """
+        nestPath: "aaa"
+        targets:
+          - http://example.com/foo.zip
+        """
+
+        fileSystem.item = [
+            "/": [
+                "User": .directory,
+                "tmp": .directory
+            ]
+        ]
+        let nestFilePath = URL(filePath: "/User/nestfile")
+        try fileSystem.write(nestFile.data(using: .utf8)!, to: nestFilePath)
+
+        #expect(throws: (any Error).self) {
+            try Nestfile.load(from: nestFilePath.path(), fileSystem: fileSystem)
+        }
+    }
 }

--- a/Tests/NestCLITests/NestfileTests.swift
+++ b/Tests/NestCLITests/NestfileTests.swift
@@ -87,4 +87,16 @@ struct NestfileTests {
         let gheServer = try #require(githubInfo.first { $0.host == "my-ghe.example.com" })
         #expect(gheServer.tokenEnvironmentVariable == "MY_GHE_TOKEN")
     }
+
+    @Test(arguments: [
+        (target: Nestfile.Target.repository(Nestfile.Repository(reference: "mtj0928/nest", version: nil, assetName: nil, checksum: nil)),
+         expected: "mtj0928/nest"),
+        (target: .zip(Nestfile.ZIPURL(zipURL: "https://example.com/foo.zip", checksum: nil)),
+         expected: "https://example.com/foo.zip"),
+        (target: .deprecatedZIP(Nestfile.DeprecatedZIPURL(url: "https://example.com/legacy.zip")),
+         expected: "https://example.com/legacy.zip"),
+    ])
+    func targetIdentifier(target: Nestfile.Target, expected: String) {
+        #expect(target.identifier == expected)
+    }
 }


### PR DESCRIPTION
## Summary

This PR strengthens artifact bundle integrity handling by adding checksum verification paths, HTTPS-only artifact bundle URL validation, and strict-mode opt-ins for workflows that want missing checksums to fail now.

The default `bootstrap` / `run` migration behavior still accepts missing nestfile checksums for now, but prints a prominent warning with the calculated checksum and remediation steps.

## Changes

- Verify artifact bundle checksums before unzipping.
- Fail installs on checksum mismatch instead of warning and continuing.
- Add `--checksum` and `--allow-unverified` to `nest install`.
- Require an explicit verification decision for direct artifact bundle ZIP installs.
- Add `--require-checksum` and `NEST_REQUIRE_CHECKSUM=1` strict-mode opt-ins for `bootstrap`, `run`, and `install`.
- Add `--skip-checksum-validation` support to `run`.
- Reject non-HTTPS direct artifact bundle ZIP URLs in nestfiles and direct install paths.
- Make `update-nestfile` / `resolve-nestfile` refuse checksum changes without a version bump unless `--allow-checksum-changes` is passed.
- Update README and tests for checksum migration, strict mode, HTTPS validation, and checksum-change detection.

## Compatibility / failure patterns investigated

The repository CI workflow itself is unchanged: PR CI runs `swift test` and `swift build -c release --arch arm64 --arch x86_64`.

For users of `nest`, the following workflows may now fail where they previously succeeded:

| Pattern | Previous behavior | New behavior | Mitigation |
| --- | --- | --- | --- |
| `nest install https://...artifactbundle.zip` without `--checksum` | Downloaded and installed unverified | Fails before install | Pass `--checksum <value>` or explicitly pass `--allow-unverified` |
| `nest install http://...artifactbundle.zip` | Accepted as a direct ZIP target | Fails because artifact bundle downloads must be HTTPS | Use HTTPS |
| `nest install artifactBundle.zip` or `file://...zip` local/direct ZIP usage | Could be parsed as an artifact bundle install target | Fails HTTPS validation in the direct artifact bundle path | Use a supported HTTPS artifact bundle URL, or keep using source-build flows |
| `nest install ... --checksum ... --allow-unverified` | No conflict handling | Fails as mutually exclusive | Use exactly one integrity mode |
| Repository install resolves a release artifact bundle and the provided checksum is wrong | Could fall back toward source build after fetch errors | Fails and does not silently fall back | Update the checksum or remove the checksum only if using the migration path intentionally |
| `nest bootstrap` / `nest run` with a nestfile checksum mismatch | Download could continue after warning | Fails before unzip/install | Run `nest update-nestfile`, or inspect the release if the mismatch is unexpected |
| `nest bootstrap` / `nest run` with missing nestfile checksums in default mode | Installed silently | Still installs, but prints a migration warning with the calculated checksum | Run `nest update-nestfile <path>` and commit populated checksums |
| `nest bootstrap --require-checksum`, `nest run --require-checksum`, or `NEST_REQUIRE_CHECKSUM=1` with missing nestfile checksums | No strict mode existed | Fails with a missing-checksum error | Populate checksums or temporarily pass `--skip-checksum-validation` |
| Fresh CI runner using `nest run` auto-install with missing checksum under strict mode | Auto-installed | Fails during auto-install | Populate checksum in the nestfile or skip validation temporarily |
| Developer machine with artifact already installed | May not download during `run` | Existing install can still bypass download-time verification | Reinstall after populating checksum to exercise verification |
| `update-nestfile` / `resolve-nestfile` when the resolved version is unchanged but the artifact checksum changed | Silently overwrote checksum | Fails as a possible retag / compromised release | Pass `--allow-checksum-changes` only after confirming the release was legitimately re-uploaded |
| nestfile direct ZIP entries using `http://` or deprecated string ZIP syntax with `http://` | Loaded successfully | Fails while loading the nestfile | Change ZIP URLs to HTTPS |

## Test plan

- `swift test`
- `swift build -c release --arch arm64 --arch x86_64`
