### PR TITLE
Enable user-scoped artifact bundle caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ The command will:
 If you want change the directory,
 please update `$NEST_PATH` or specify `nestPath` in a configuration file (only `bootstrap`).
 
+To reuse downloaded artifact bundle ZIP files across multiple nest paths, pass `--enable-user-scope-cache` when installing:
+
+```sh
+$ nest install realm/SwiftLint --enable-user-scope-cache
+$ nest bootstrap nestfile.yaml --enable-user-scope-cache
+$ nest run --enable-user-scope-cache realm/SwiftLint foo.swift
+```
+
+When this option is enabled, nest stores the downloaded ZIP file as-is under `~/Library/Caches/nest/artifact-bundle-zips`. The cache mirrors a safe, bounded portion of the source URL for readability and adds a URL hash to the ZIP file name for uniqueness. If a matching ZIP is already cached there, nest reuses it for checksum validation and installation instead of downloading the ZIP again.
+
 ## Use GitHub API token to fetch Artifact Bundles
 
 Fetching releases sometimes fails due to API limit, so we recommended to pass a GitHub API token.

--- a/Sources/NestCLI/ArtifactBundleFetcher.swift
+++ b/Sources/NestCLI/ArtifactBundleFetcher.swift
@@ -66,10 +66,7 @@ public struct ArtifactBundleFetcher {
         let repositoryDirectory = workingDirectory.appending(component: gitURL.fileNameWithoutPathExtension)
         try fileSystem.removeItemIfExists(at: repositoryDirectory)
 
-        // Prepare the artifact bundle.
-        logger.info("📦 Preparing the artifact bundle of \(gitURL.lastPathComponent)...")
         try await downloadZIPFile(from: resolvedAsset.zipURL, to: repositoryDirectory, checksum: checksum)
-        logger.info("✅ Success to prepare the artifact bundle of \(gitURL.lastPathComponent).", metadata: .color(.green))
 
         // Get the current triple.
         let triple = try await tripleDetector.detect()
@@ -99,10 +96,7 @@ public struct ArtifactBundleFetcher {
         let directory = workingDirectory.appending(component: url.fileNameWithoutPathExtension)
         try fileSystem.removeItemIfExists(at: directory)
 
-        // Prepare the artifact bundle.
-        logger.info("📦 Preparing the artifact bundle at \(url.absoluteString)...")
         try await downloadZIPFile(from: url, to: directory, checksum: checksum)
-        logger.info("✅ Success to prepare the artifact bundle of \(url.lastPathComponent).", metadata: .color(.green))
 
         // Get the current triple.
         let triple = try await tripleDetector.detect()
@@ -172,7 +166,8 @@ public struct ArtifactBundleFetcher {
         defer { try? fileSystem.removeItemIfExists(at: temporaryZIPFilePath) }
         if let cacheFilePath,
            fileSystem.fileExists(atPath: cacheFilePath.path()) {
-            logger.info("📦 Using cached artifact bundle ZIP at \(cacheFilePath.path()).")
+            logger.info("🔄 Reusing the artifact bundle ZIP from the user cache.")
+            logger.debug("The cached artifact bundle ZIP is at \(cacheFilePath.path()).")
             do {
                 try await prepareZIPFile(
                     at: cacheFilePath,
@@ -270,7 +265,8 @@ public struct ArtifactBundleFetcher {
     private func storeZIPFileInCache(at sourceURL: URL, to cacheFilePath: URL) {
         do {
             try fileSystem.copyItemAtomicallyReplacingDestination(at: sourceURL, to: cacheFilePath)
-            logger.info("📦 Cached artifact bundle ZIP at \(cacheFilePath.path()).")
+            logger.info("📦 Cached artifact bundle ZIP.")
+            logger.debug("The artifact bundle ZIP was cached at \(cacheFilePath.path()).")
         } catch {
             logger.warning("⚠️ Failed to cache the artifact bundle ZIP: \(error.localizedDescription)")
         }

--- a/Sources/NestCLI/ArtifactBundleFetcher.swift
+++ b/Sources/NestCLI/ArtifactBundleFetcher.swift
@@ -11,6 +11,7 @@ public struct ArtifactBundleFetcher {
     private let assetRegistryClientBuilder: AssetRegistryClientBuilder
     private let checksumCalculator: any ChecksumCalculator
     private let tripleDetector: TripleDetector
+    private let artifactBundleZIPCacheOption: ArtifactBundleZIPCacheOption
     private let logger: Logger
 
     public init(
@@ -20,6 +21,7 @@ public struct ArtifactBundleFetcher {
         fileDownloader: some FileDownloader,
         nestInfoController: NestInfoController,
         assetRegistryClientBuilder: AssetRegistryClientBuilder,
+        artifactBundleZIPCacheOption: ArtifactBundleZIPCacheOption,
         logger: Logger
     ) {
         self.workingDirectory = workingDirectory
@@ -30,6 +32,7 @@ public struct ArtifactBundleFetcher {
         self.assetRegistryClientBuilder = assetRegistryClientBuilder
         self.checksumCalculator = SwiftChecksumCalculator(swift: SwiftCommand(executor: executorBuilder.build()))
         self.tripleDetector = TripleDetector(swiftCommand: SwiftCommand(executor: executorBuilder.build()))
+        self.artifactBundleZIPCacheOption = artifactBundleZIPCacheOption
         self.logger = logger
     }
     
@@ -63,10 +66,10 @@ public struct ArtifactBundleFetcher {
         let repositoryDirectory = workingDirectory.appending(component: gitURL.fileNameWithoutPathExtension)
         try fileSystem.removeItemIfExists(at: repositoryDirectory)
 
-        // Download the artifact bundle
-        logger.info("🌐 Downloading the artifact bundle of \(gitURL.lastPathComponent)...")
+        // Prepare the artifact bundle.
+        logger.info("📦 Preparing the artifact bundle of \(gitURL.lastPathComponent)...")
         try await downloadZIPFile(from: resolvedAsset.zipURL, to: repositoryDirectory, checksum: checksum)
-        logger.info("✅ Success to download the artifact bundle of \(gitURL.lastPathComponent).", metadata: .color(.green))
+        logger.info("✅ Success to prepare the artifact bundle of \(gitURL.lastPathComponent).", metadata: .color(.green))
 
         // Get the current triple.
         let triple = try await tripleDetector.detect()
@@ -96,10 +99,10 @@ public struct ArtifactBundleFetcher {
         let directory = workingDirectory.appending(component: url.fileNameWithoutPathExtension)
         try fileSystem.removeItemIfExists(at: directory)
 
-        // Download the artifact bundle
-        logger.info("🌐 Downloading the artifact bundle at \(url.absoluteString)...")
+        // Prepare the artifact bundle.
+        logger.info("📦 Preparing the artifact bundle at \(url.absoluteString)...")
         try await downloadZIPFile(from: url, to: directory, checksum: checksum)
-        logger.info("✅ Success to download the artifact bundle of \(url.lastPathComponent).", metadata: .color(.green))
+        logger.info("✅ Success to prepare the artifact bundle of \(url.lastPathComponent).", metadata: .color(.green))
 
         // Get the current triple.
         let triple = try await tripleDetector.detect()
@@ -147,23 +150,74 @@ public struct ArtifactBundleFetcher {
         )
     }
 
-    private func downloadZIPFile(from url: URL, to destination: URL, checksum: ChecksumOption) async throws  {
+    private func downloadZIPFile(from url: URL, to destination: URL, checksum: ChecksumOption) async throws {
         // Surface checksum flag conflicts before spending bandwidth on a
         // download whose archive we cannot accept anyway.
         if url.needsUnzip, case .unresolvable(let error) = checksum {
             throw error
         }
-        let downloadedFilePath = try await fileDownloader.download(url: url)
         if !url.needsUnzip {
+            let downloadedFilePath = try await fileDownloader.download(url: url)
             if case .unresolvable(let error) = checksum {
                 throw error
             }
             try fileSystem.copyItem(at: downloadedFilePath, to: destination)
             return
         }
-        let downloadedZipFilePath = fileSystem.temporaryDirectory.appendingPathComponent(url.lastPathComponent)
-        try fileSystem.removeItemIfExists(at: downloadedZipFilePath)
-        try fileSystem.copyItem(at: downloadedFilePath, to: downloadedZipFilePath)
+
+        let cacheFilePath = artifactBundleZIPCacheOption.cacheFileURL(for: url)
+        let temporaryZIPFilePath = fileSystem.temporaryDirectory.appending(
+            component: "nest-artifact-bundle-\(UUID().uuidString).zip"
+        )
+        defer { try? fileSystem.removeItemIfExists(at: temporaryZIPFilePath) }
+        if let cacheFilePath,
+           fileSystem.fileExists(atPath: cacheFilePath.path()) {
+            logger.info("📦 Using cached artifact bundle ZIP at \(cacheFilePath.path()).")
+            do {
+                try await prepareZIPFile(
+                    at: cacheFilePath,
+                    temporaryZIPFilePath: temporaryZIPFilePath,
+                    destination: destination,
+                    checksum: checksum
+                )
+                return
+            } catch {
+                if !error.invalidatesArtifactBundleZIPCache {
+                    throw error
+                }
+                logger.warning(
+                    """
+                    ⚠️ Cached artifact bundle ZIP is unusable and will be downloaded again: \
+                    \(error.localizedDescription)
+                    """
+                )
+                try? fileSystem.removeItemIfExists(at: cacheFilePath)
+                try fileSystem.removeItemIfExists(at: destination)
+            }
+        }
+
+        logger.info("🌐 Downloading the artifact bundle ZIP at \(url.absoluteString)...")
+        let downloadedZIPFilePath = try await fileDownloader.download(url: url)
+        try await prepareZIPFile(
+            at: downloadedZIPFilePath,
+            temporaryZIPFilePath: temporaryZIPFilePath,
+            destination: destination,
+            checksum: checksum
+        )
+
+        if let cacheFilePath {
+            storeZIPFileInCache(at: temporaryZIPFilePath, to: cacheFilePath)
+        }
+    }
+
+    private func prepareZIPFile(
+        at sourceURL: URL,
+        temporaryZIPFilePath: URL,
+        destination: URL,
+        checksum: ChecksumOption
+    ) async throws {
+        try fileSystem.removeItemIfExists(at: temporaryZIPFilePath)
+        try fileSystem.copyItem(at: sourceURL, to: temporaryZIPFilePath)
 
         switch checksum {
         case .unresolvable(let error):
@@ -172,7 +226,7 @@ public struct ArtifactBundleFetcher {
             // TODO: Make missing checksums a hard error after the migration period ends.
             // Keep this warning path only until existing CI users have had enough time
             // to populate nestfile checksums with `nest update-nestfile`.
-            let calculatedChecksum = try await checksumCalculator.calculate(downloadedZipFilePath.path())
+            let calculatedChecksum = try await checksumCalculator.calculate(temporaryZIPFilePath.path())
             logger.warning(
                 """
 
@@ -196,7 +250,7 @@ public struct ArtifactBundleFetcher {
                 metadata: .color(.yellow)
             )
         case .needsCheck(let expectedChecksum):
-            let calculatedChecksum = try await checksumCalculator.calculate(downloadedZipFilePath.path())
+            let calculatedChecksum = try await checksumCalculator.calculate(temporaryZIPFilePath.path())
             if expectedChecksum != calculatedChecksum {
                 throw ArtifactBundleFetcherError.checksumMismatch(
                     expected: expectedChecksum,
@@ -204,13 +258,31 @@ public struct ArtifactBundleFetcher {
                 )
             }
         case .printActual(let handler):
-            let calculatedChecksum = try await checksumCalculator.calculate(downloadedZipFilePath.path())
+            let calculatedChecksum = try await checksumCalculator.calculate(temporaryZIPFilePath.path())
             handler(calculatedChecksum)
         case .skip:
             break
         }
 
-        try fileSystem.unzip(at: downloadedFilePath, to: destination)
+        try fileSystem.unzip(at: temporaryZIPFilePath, to: destination)
+    }
+
+    private func storeZIPFileInCache(at sourceURL: URL, to cacheFilePath: URL) {
+        do {
+            try fileSystem.copyItemAtomicallyReplacingDestination(at: sourceURL, to: cacheFilePath)
+            logger.info("📦 Cached artifact bundle ZIP at \(cacheFilePath.path()).")
+        } catch {
+            logger.warning("⚠️ Failed to cache the artifact bundle ZIP: \(error.localizedDescription)")
+        }
+    }
+}
+
+extension ArtifactBundleZIPCacheOption {
+    fileprivate func cacheFileURL(for remoteURL: URL) -> URL? {
+        switch self {
+        case .enableCache(let artifactBundleZIPCache): artifactBundleZIPCache.fileURL(for: remoteURL)
+        case .disableCache: nil
+        }
     }
 }
 
@@ -233,6 +305,21 @@ extension ArtifactBundle {
                 throw ArtifactBundleFetcherError.unsupportedTriple
             }
             return binaries
+        }
+    }
+}
+
+private extension Error {
+    var invalidatesArtifactBundleZIPCache: Bool {
+        if self is InvalidZIPArchiveError {
+            return true
+        }
+        guard let artifactBundleFetcherError = self as? ArtifactBundleFetcherError else {
+            return false
+        }
+        return switch artifactBundleFetcherError {
+        case .checksumMismatch: true
+        default: false
         }
     }
 }

--- a/Sources/NestKit/ArtifactBundleZIPCache.swift
+++ b/Sources/NestKit/ArtifactBundleZIPCache.swift
@@ -1,0 +1,56 @@
+import CryptoKit
+import Foundation
+
+/// Resolves stable user-scope cache locations for artifact bundle ZIP files.
+public struct ArtifactBundleZIPCache: Sendable {
+    private static let maximumReadablePathDepth = 8
+
+    /// The root directory where cached ZIP files are stored.
+    public let directory: URL
+
+    /// Creates a cache rooted at the given directory.
+    public init(directory: URL) {
+        self.directory = directory
+    }
+
+    /// Returns the cache file URL corresponding to a remote artifact bundle ZIP URL.
+    public func fileURL(for remoteURL: URL) -> URL {
+        let scheme = (remoteURL.scheme ?? "unknown-scheme").artifactBundleZIPCachePathComponent
+        let host = (remoteURL.host() ?? "unknown-host").artifactBundleZIPCachePathComponent
+        let authority = remoteURL.port.map { "\(host)-\($0)" } ?? host
+        let readablePathComponents = remoteURL.pathComponents
+            .filter { $0 != "/" }
+            .dropLast()
+            .prefix(Self.maximumReadablePathDepth)
+            .map(\.artifactBundleZIPCachePathComponent)
+        let cacheDirectory = ([scheme, authority] + readablePathComponents)
+            .reduce(directory) { $0.appending(component: $1) }
+        let remoteFileStem = remoteURL.deletingPathExtension().lastPathComponent
+        let readableFileStem = (remoteFileStem.isEmpty ? "artifact-bundle" : remoteFileStem)
+            .artifactBundleZIPCachePathComponent
+
+        return cacheDirectory.appending(component: "\(readableFileStem)-\(cacheKey(for: remoteURL)).zip")
+    }
+
+    private func cacheKey(for remoteURL: URL) -> String {
+        var components = URLComponents(url: remoteURL, resolvingAgainstBaseURL: false)
+        components?.fragment = nil
+        let cacheIdentity = components?.string ?? remoteURL.absoluteString
+        return SHA256.hash(data: Data(cacheIdentity.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+}
+
+private extension String {
+    var artifactBundleZIPCachePathComponent: String {
+        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._"))
+        let encoded = addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? "unknown"
+        let nonempty = encoded.isEmpty ? "unknown" : encoded
+        let traversalSafe = switch nonempty {
+        case ".", "..": "_\(nonempty)"
+        default: nonempty
+        }
+        return String(traversalSafe.prefix(80))
+    }
+}

--- a/Sources/NestKit/ArtifactBundleZIPCacheOption.swift
+++ b/Sources/NestKit/ArtifactBundleZIPCacheOption.swift
@@ -1,0 +1,8 @@
+/// A user-scope artifact bundle ZIP cache option.
+public enum ArtifactBundleZIPCacheOption: Sendable {
+    /// Enables the user-scope artifact bundle ZIP cache.
+    case enableCache(ArtifactBundleZIPCache)
+
+    /// Disables the user-scope artifact bundle ZIP cache.
+    case disableCache
+}

--- a/Sources/NestKit/Configuration.swift
+++ b/Sources/NestKit/Configuration.swift
@@ -8,6 +8,7 @@ public struct Configuration: Sendable {
     public var workingDirectory: URL
     public var assetRegistryClientBuilder: AssetRegistryClientBuilder
     public var nestDirectory: NestDirectory
+    public var artifactBundleZIPCacheOption: ArtifactBundleZIPCacheOption
     public var artifactBundleManager: ArtifactBundleManager
     public var logger: Logger
 
@@ -18,6 +19,7 @@ public struct Configuration: Sendable {
         workingDirectory: URL,
         assetRegistryClientBuilder: AssetRegistryClientBuilder,
         nestDirectory: NestDirectory,
+        artifactBundleZIPCacheOption: ArtifactBundleZIPCacheOption,
         artifactBundleManager: ArtifactBundleManager,
         logger: Logger
     ) {
@@ -27,6 +29,7 @@ public struct Configuration: Sendable {
         self.workingDirectory = workingDirectory
         self.assetRegistryClientBuilder = assetRegistryClientBuilder
         self.nestDirectory = nestDirectory
+        self.artifactBundleZIPCacheOption = artifactBundleZIPCacheOption
         self.artifactBundleManager = artifactBundleManager
         self.logger = logger
     }

--- a/Sources/NestKit/FileSystem.swift
+++ b/Sources/NestKit/FileSystem.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import ZIPFoundation
 
@@ -14,6 +15,7 @@ public protocol FileSystem: Sendable {
     func removeItem(at URL: URL) throws
     func child(at url: URL) throws -> [URL]
     func copyItem(at srcURL: URL, to dstURL: URL) throws
+    func replaceItemAtomically(at sourceURL: URL, to destinationURL: URL) throws
     func createSymbolicLink(at url: URL, withDestinationURL destURL: URL) throws
     func destinationOfSymbolicLink(atPath path: String) throws -> String
     func unzip(
@@ -38,14 +40,18 @@ extension FileSystem {
     }
 
     public func unzip(at sourceURL: URL, to destinationURL: URL) throws {
-        try unzip(
-            at: sourceURL,
-            to: destinationURL,
-            skipCRC32: false,
-            allowUncontainedSymlinks: false,
-            progress: nil,
-            pathEncoding: nil
-        )
+        do {
+            try unzip(
+                at: sourceURL,
+                to: destinationURL,
+                skipCRC32: false,
+                allowUncontainedSymlinks: false,
+                progress: nil,
+                pathEncoding: nil
+            )
+        } catch let error as Archive.ArchiveError {
+            throw InvalidZIPArchiveError(underlyingError: error)
+        }
     }
 
     public func child(extension extensionName: String, at url: URL) throws -> [URL] {
@@ -57,6 +63,20 @@ extension FileSystem {
         if fileExists(atPath: path.path()) {
             try removeItem(at: path)
         }
+    }
+
+    /// Copies a file to a sibling temporary path and atomically publishes the completed copy.
+    public func copyItemAtomicallyReplacingDestination(at sourceURL: URL, to destinationURL: URL) throws {
+        let destinationDirectory = destinationURL.deletingLastPathComponent()
+        try createDirectory(at: destinationDirectory, withIntermediateDirectories: true)
+
+        let temporaryURL = destinationDirectory.appending(
+            component: ".\(destinationURL.lastPathComponent).\(UUID().uuidString).tmp"
+        )
+        defer { try? removeItemIfExists(at: temporaryURL) }
+
+        try copyItem(at: sourceURL, to: temporaryURL)
+        try replaceItemAtomically(at: temporaryURL, to: destinationURL)
     }
 
     public func child(at url: URL) throws -> [URL] {
@@ -75,6 +95,13 @@ extension FileSystem {
 }
 
 extension FileManager: FileSystem {
+    public func replaceItemAtomically(at sourceURL: URL, to destinationURL: URL) throws {
+        if Darwin.rename(sourceURL.path(), destinationURL.path()) != 0 {
+            let errorCode = errno
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errorCode))
+        }
+    }
+
     public func data(at url: URL) throws -> Data {
         try Data(contentsOf: url)
     }

--- a/Sources/NestKit/InvalidZIPArchiveError.swift
+++ b/Sources/NestKit/InvalidZIPArchiveError.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+package struct InvalidZIPArchiveError: LocalizedError {
+    package let errorDescription: String?
+
+    package init(underlyingError: any Error) {
+        self.errorDescription = underlyingError.localizedDescription
+    }
+}

--- a/Sources/NestTestHelpers/MockFileSystem.swift
+++ b/Sources/NestTestHelpers/MockFileSystem.swift
@@ -1,7 +1,7 @@
 import Foundation
-import ZIPFoundation
-import os
 import NestKit
+import os
+import ZIPFoundation
 
 public final class MockFileSystem: FileSystem, Sendable {
     public var item: FileSystemItem {
@@ -12,12 +12,17 @@ public final class MockFileSystem: FileSystem, Sendable {
         get { lockedSymbolicLink.withLock { $0 } }
         set { lockedSymbolicLink.withLock { $0 = newValue } }
     }
+    public var unzipError: MockFileSystemError? {
+        get { lockedUnzipError.withLock { $0 } }
+        set { lockedUnzipError.withLock { $0 = newValue } }
+    }
 
     public let homeDirectoryForCurrentUser: URL
     public let temporaryDirectory: URL
 
     private let lockedItem = OSAllocatedUnfairLock(initialState: FileSystemItem.directory(children: [:]))
     private let lockedSymbolicLink = OSAllocatedUnfairLock(initialState: [URL: URL]())
+    private let lockedUnzipError = OSAllocatedUnfairLock<MockFileSystemError?>(initialState: nil)
 
     public init(homeDirectoryForCurrentUser: URL, temporaryDirectory: URL) {
         self.homeDirectoryForCurrentUser = homeDirectoryForCurrentUser
@@ -77,6 +82,19 @@ public final class MockFileSystem: FileSystem, Sendable {
         }
     }
 
+    public func replaceItemAtomically(at sourceURL: URL, to destinationURL: URL) throws {
+        try lockedItem.withLock { item in
+            let sourceURL = symbolicLink[sourceURL] ?? sourceURL
+            let destinationURL = symbolicLink[destinationURL] ?? destinationURL
+            guard let sourceItem = item.item(components: sourceURL.pathComponents) else {
+                throw MockFileSystemError.fileNotFound
+            }
+            item.remove(at: destinationURL.pathComponents)
+            item.update(item: sourceItem, at: destinationURL.pathComponents)
+            item.remove(at: sourceURL.pathComponents)
+        }
+    }
+
     public func createSymbolicLink(at url: URL, withDestinationURL destURL: URL) throws {
         symbolicLink[url] = destURL
     }
@@ -105,6 +123,9 @@ public final class MockFileSystem: FileSystem, Sendable {
         progress: Progress?,
         pathEncoding: String.Encoding?
     ) throws {
+        if let unzipError {
+            throw unzipError
+        }
         let sourceURL = symbolicLink[sourceURL] ?? sourceURL
         let destinationURL = symbolicLink[destinationURL] ?? destinationURL
         try createDirectory(at: destinationURL, withIntermediateDirectories: true)
@@ -158,7 +179,8 @@ extension MockFileSystem {
         }
     }
 
-    public enum MockFileSystemError: Error {
+    public enum MockFileSystemError: Error, Equatable, Sendable {
+        case destinationUnavailable
         case fileNotFound
     }
 }

--- a/Sources/nest/Arguments/CacheOptions.swift
+++ b/Sources/nest/Arguments/CacheOptions.swift
@@ -1,0 +1,6 @@
+import ArgumentParser
+
+struct CacheOptions: ParsableArguments {
+    @Flag(name: .customLong("enable-user-scope-cache"), help: "Cache downloaded artifact bundle ZIPs in the user cache directory and reuse them across nest paths.")
+    var enableUserScopeCache = false
+}

--- a/Sources/nest/Commands/BootstrapCommand.swift
+++ b/Sources/nest/Commands/BootstrapCommand.swift
@@ -19,6 +19,9 @@ struct BootstrapCommand: AsyncParsableCommand {
     @Flag(name: [.customLong("skip-checksum-validation"), .customShort("s")], help: .hidden)
     var skipChecksumValidation = false
 
+    @OptionGroup
+    var cacheOptions: CacheOptions
+
     @Flag(name: .shortAndLong)
     var verbose: Bool = false
 
@@ -128,7 +131,8 @@ extension BootstrapCommand {
         let configuration = Configuration.make(
             nestPath: nestfile.nestPath ?? ProcessInfo.processInfo.nestPath,
             registryTokenEnvironmentVariableNames: nestfile.registries?.githubServerTokenEnvironmentVariableNames ?? [:],
-            logLevel: verbose ? .trace : .info
+            logLevel: verbose ? .trace : .info,
+            enableUserScopeCache: cacheOptions.enableUserScopeCache
         )
 
         return (

--- a/Sources/nest/Commands/GenerateNestfileCommand.swift
+++ b/Sources/nest/Commands/GenerateNestfileCommand.swift
@@ -1,8 +1,8 @@
 import ArgumentParser
 import Foundation
+import Logging
 import NestCLI
 import NestKit
-import Logging
 
 struct GenerateNestfileCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -30,7 +30,8 @@ extension GenerateNestfileCommand {
         LoggingSystem.bootstrap()
         let configuration = Configuration.make(
             nestPath: ProcessInfo.processInfo.nestPath,
-            logLevel: verbose ? .trace : .info
+            logLevel: verbose ? .trace : .info,
+            enableUserScopeCache: false
         )
 
         return configuration.logger

--- a/Sources/nest/Commands/InstallCommand.swift
+++ b/Sources/nest/Commands/InstallCommand.swift
@@ -24,6 +24,9 @@ struct InstallCommand: AsyncParsableCommand {
     @Option(help: "Checksum validation policy for downloaded artifact bundles: skip, warn, or require.")
     var checksumPolicy: ChecksumValidationPolicyArgument?
 
+    @OptionGroup
+    var cacheOptions: CacheOptions
+
     @Flag(name: .shortAndLong)
     var verbose: Bool = false
 
@@ -141,7 +144,8 @@ extension InstallCommand {
         LoggingSystem.bootstrap()
         let configuration = Configuration.make(
             nestPath: ProcessInfo.processInfo.nestPath,
-            logLevel: verbose ? .trace : .info
+            logLevel: verbose ? .trace : .info,
+            enableUserScopeCache: cacheOptions.enableUserScopeCache
         )
 
         return (

--- a/Sources/nest/Commands/ListCommand.swift
+++ b/Sources/nest/Commands/ListCommand.swift
@@ -1,8 +1,8 @@
 import ArgumentParser
 import Foundation
+import Logging
 import NestCLI
 import NestKit
-import Logging
 
 struct ListCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -38,7 +38,8 @@ extension ListCommand {
         LoggingSystem.bootstrap()
         let configuration = Configuration.make(
             nestPath: ProcessInfo.processInfo.nestPath,
-            logLevel: verbose ? .trace : .info
+            logLevel: verbose ? .trace : .info,
+            enableUserScopeCache: false
         )
 
         return (

--- a/Sources/nest/Commands/ResolveNestfileCommand.swift
+++ b/Sources/nest/Commands/ResolveNestfileCommand.swift
@@ -1,9 +1,9 @@
 import ArgumentParser
 import AsyncOperations
 import Foundation
+import Logging
 import NestCLI
 import NestKit
-import Logging
 
 struct ResolveNestfileCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -35,7 +35,8 @@ extension ResolveNestfileCommand {
         let configuration = Configuration.make(
             nestPath: nestfile.nestPath ?? ProcessInfo.processInfo.nestPath,
             registryTokenEnvironmentVariableNames: nestfile.registries?.githubServerTokenEnvironmentVariableNames ?? [:],
-            logLevel: verbose ? .trace : .info
+            logLevel: verbose ? .trace : .info,
+            enableUserScopeCache: false
         )
         let controller = NestfileController(
             assetRegistryClientBuilder: AssetRegistryClientBuilder(

--- a/Sources/nest/Commands/RunCommand.swift
+++ b/Sources/nest/Commands/RunCommand.swift
@@ -22,6 +22,9 @@ struct RunCommand: AsyncParsableCommand {
     @Flag(name: [.customLong("skip-checksum-validation"), .customShort("s")], help: .hidden)
     var skipChecksumValidation = false
 
+    @OptionGroup
+    var cacheOptions: CacheOptions
+
     @Option(help: "A path to nestfile", completion: .file(extensions: ["yaml"]))
     var nestfilePath = "nestfile.yaml"
 
@@ -117,7 +120,8 @@ extension RunCommand {
         let configuration = Configuration.make(
             nestPath: nestfile.nestPath ?? ProcessInfo.processInfo.nestPath,
             registryTokenEnvironmentVariableNames: nestfile.registries?.githubServerTokenEnvironmentVariableNames ?? [:],
-            logLevel: verbose ? .trace : .info
+            logLevel: verbose ? .trace : .info,
+            enableUserScopeCache: cacheOptions.enableUserScopeCache
         )
 
         let controller = NestfileController(

--- a/Sources/nest/Commands/SwitchCommand.swift
+++ b/Sources/nest/Commands/SwitchCommand.swift
@@ -1,8 +1,8 @@
 import ArgumentParser
 import Foundation
+import Logging
 import NestCLI
 import NestKit
-import Logging
 
 struct SwitchCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -78,7 +78,8 @@ extension SwitchCommand {
         LoggingSystem.bootstrap()
         let configuration = Configuration.make(
             nestPath: ProcessInfo.processInfo.nestPath,
-            logLevel: verbose ? .trace : .info
+            logLevel: verbose ? .trace : .info,
+            enableUserScopeCache: false
         )
 
         return (

--- a/Sources/nest/Commands/UninstallCommand.swift
+++ b/Sources/nest/Commands/UninstallCommand.swift
@@ -1,8 +1,8 @@
 import ArgumentParser
 import Foundation
+import Logging
 import NestCLI
 import NestKit
-import Logging
 
 struct UninstallCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -54,7 +54,8 @@ extension UninstallCommand {
         LoggingSystem.bootstrap()
         let configuration = Configuration.make(
             nestPath: ProcessInfo.processInfo.nestPath,
-            logLevel: verbose ? .trace : .info
+            logLevel: verbose ? .trace : .info,
+            enableUserScopeCache: false
         )
 
         return (

--- a/Sources/nest/Commands/UpdateNestfileCommand.swift
+++ b/Sources/nest/Commands/UpdateNestfileCommand.swift
@@ -1,9 +1,9 @@
 import ArgumentParser
 import AsyncOperations
 import Foundation
+import Logging
 import NestCLI
 import NestKit
-import Logging
 
 struct UpdateNestfileCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -42,7 +42,8 @@ extension UpdateNestfileCommand {
         let configuration = Configuration.make(
             nestPath: nestfile.nestPath ?? ProcessInfo.processInfo.nestPath,
             registryTokenEnvironmentVariableNames: nestfile.registries?.githubServerTokenEnvironmentVariableNames ?? [:],
-            logLevel: verbose ? .trace : .info
+            logLevel: verbose ? .trace : .info,
+            enableUserScopeCache: false
         )
         let controller = NestfileController(
             assetRegistryClientBuilder: AssetRegistryClientBuilder(

--- a/Sources/nest/Utils/Configuration+Dependencies.swift
+++ b/Sources/nest/Utils/Configuration+Dependencies.swift
@@ -25,6 +25,7 @@ extension Configuration {
             fileDownloader: NestFileDownloader(httpClient: httpClient),
             nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
             assetRegistryClientBuilder: assetRegistryClientBuilder,
+            artifactBundleZIPCacheOption: artifactBundleZIPCacheOption,
             logger: logger
         )
     }

--- a/Sources/nest/nest.swift
+++ b/Sources/nest/nest.swift
@@ -27,6 +27,7 @@ extension Configuration {
         nestPath: String?,
         registryTokenEnvironmentVariableNames: [Nestfile.RegistryConfigs.GitHubHost: String] = [:],
         logLevel: Logger.Level,
+        enableUserScopeCache: Bool,
         httpClient: some HTTPClient = URLSession.shared,
         fileSystem: some FileSystem = FileManager.default
     ) -> Configuration {
@@ -53,6 +54,9 @@ extension Configuration {
             workingDirectory: fileSystem.temporaryDirectory.appending(path: "nest"),
             assetRegistryClientBuilder: assetRegistryClientBuilder,
             nestDirectory: nestDirectory,
+            artifactBundleZIPCacheOption: enableUserScopeCache
+                ? .enableCache(ArtifactBundleZIPCache(directory: fileSystem.defaultUserScopeCachePath.appending(component: "artifact-bundle-zips")))
+                : .disableCache,
             artifactBundleManager: ArtifactBundleManager(fileSystem: fileSystem, directory: nestDirectory),
             logger: logger
         )
@@ -62,6 +66,10 @@ extension Configuration {
 extension FileSystem {
     var defaultNestPath: URL {
         homeDirectoryForCurrentUser.appending(component: ".nest")
+    }
+
+    var defaultUserScopeCachePath: URL {
+        homeDirectoryForCurrentUser.appending(components: "Library", "Caches", "nest")
     }
 }
 

--- a/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
+++ b/Tests/NestCLITests/ArtfactBundleFetcherTests.swift
@@ -1,21 +1,29 @@
-import Testing
-import NestCLI
-import NestKit
 import Foundation
 import Logging
+import NestCLI
+import NestKit
 import NestTestHelpers
+import Testing
 
 struct ArtfactBundleFetcherTests {
     let logger = Logger(label: "test")
     let nestDirectory = NestDirectory(rootDirectory: URL(filePath: "/User/.nest"))
-    let executorBuilder = MockExecutorBuilder(dummy: [
-        "/usr/bin/which swift": "/usr/bin/swift",
-        "/usr/bin/swift -print-target-info": """
+    let executorBuilder = MockExecutorBuilder { command, arguments in
+        let command = ([command] + arguments).joined(separator: " ")
+        switch command {
+        case "/usr/bin/which swift":
+            return "/usr/bin/swift"
+        case "/usr/bin/swift -print-target-info":
+            return """
                 { "target": { "unversionedTriple": "arm64-apple-macosx" } }
-                """,
-        "/usr/bin/swift package compute-checksum /tmp/artifactbundle.zip": "aaa",
-        "/usr/bin/swift package compute-checksum /tmp/repo.zip": "aaa"
-    ])
+                """
+        case let command where command.hasPrefix("/usr/bin/swift package compute-checksum /tmp/nest-artifact-bundle-"):
+            return "aaa"
+        default:
+            Issue.record("Unexpected command: \(command)")
+            return ""
+        }
+    }
     let fileSystem = MockFileSystem(
         homeDirectoryForCurrentUser: URL(filePath: "/User"),
         temporaryDirectory: URL(filePath: "/tmp")
@@ -49,6 +57,7 @@ struct ArtfactBundleFetcherTests {
             fileDownloader: fileDownloader,
             nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
             assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            artifactBundleZIPCacheOption: .disableCache,
             logger: logger
         )
         let result = try await fetcher.downloadArtifactBundle(url: zipURL, checksum: .skip)
@@ -66,6 +75,9 @@ struct ArtfactBundleFetcherTests {
         let zipURL = try #require(URL(string: "https://example.com/artifactbundle.zip"))
         let httpClient = MockHTTPClient(mockFileSystem: fileSystem)
         httpClient.dummyData = [zipURL: try Data(contentsOf: artifactBundlePath)]
+        let zipCache = ArtifactBundleZIPCache(
+            directory: URL(filePath: "/User/Library/Caches/nest/artifact-bundle-zips")
+        )
 
         let fileDownloader = NestFileDownloader(httpClient: httpClient)
         let fetcher = ArtifactBundleFetcher(
@@ -74,7 +86,12 @@ struct ArtfactBundleFetcherTests {
             fileSystem: fileSystem,
             fileDownloader: fileDownloader,
             nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
-            assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(
+                httpClient: httpClient,
+                registryConfigs: nil,
+                logger: logger
+            ),
+            artifactBundleZIPCacheOption: .enableCache(zipCache),
             logger: logger
         )
 
@@ -89,6 +106,7 @@ struct ArtfactBundleFetcherTests {
         // verification fails: unzip must not run before verification.
         let destination = workingDirectory.appending(component: zipURL.fileNameWithoutPathExtension)
         #expect(!fileSystem.fileExists(atPath: destination.path()))
+        #expect(!fileSystem.fileExists(atPath: zipCache.fileURL(for: zipURL).path()))
     }
 
     @Test
@@ -106,6 +124,7 @@ struct ArtfactBundleFetcherTests {
             fileDownloader: fileDownloader,
             nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
             assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            artifactBundleZIPCacheOption: .disableCache,
             logger: logger
         )
 
@@ -132,6 +151,7 @@ struct ArtfactBundleFetcherTests {
             fileDownloader: fileDownloader,
             nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
             assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            artifactBundleZIPCacheOption: .disableCache,
             logger: logger
         )
 
@@ -163,6 +183,7 @@ struct ArtfactBundleFetcherTests {
             fileDownloader: fileDownloader,
             nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
             assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            artifactBundleZIPCacheOption: .disableCache,
             logger: logger
         )
 
@@ -207,6 +228,7 @@ struct ArtfactBundleFetcherTests {
             fileDownloader: fileDownloader,
             nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
             assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            artifactBundleZIPCacheOption: .disableCache,
             logger: logger
         )
         let gitRepositoryURL = try #require(URL(string: "https://github.com/owner/repo"))
@@ -228,6 +250,190 @@ struct ArtfactBundleFetcherTests {
             ))
         )]
         #expect(result == expected)
+    }
+
+    @Test
+    func downloadArtifactBundleStoresZIPInUserScopeCache() async throws {
+        let workingDirectory = URL(filePath: "/tmp/nest")
+        let zipURL = try #require(URL(string: "https://example.com/artifactbundle.zip"))
+        let zipData = try Data(contentsOf: artifactBundlePath)
+        let httpClient = MockHTTPClient(mockFileSystem: fileSystem)
+        httpClient.dummyData = [zipURL: zipData]
+        let zipCache = ArtifactBundleZIPCache(directory: URL(filePath: "/User/Library/Caches/nest/artifact-bundle-zips"))
+
+        let fileDownloader = NestFileDownloader(httpClient: httpClient)
+        let fetcher = ArtifactBundleFetcher(
+            workingDirectory: workingDirectory,
+            executorBuilder: executorBuilder,
+            fileSystem: fileSystem,
+            fileDownloader: fileDownloader,
+            nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            artifactBundleZIPCacheOption: .enableCache(zipCache),
+            logger: logger
+        )
+
+        _ = try await fetcher.downloadArtifactBundle(url: zipURL, checksum: .skip)
+
+        let cachedZIPURL = zipCache.fileURL(for: zipURL)
+        #expect(try fileSystem.data(at: cachedZIPURL) == zipData)
+    }
+
+    @Test
+    func downloadArtifactBundleRemovesOperationScopedTemporaryZIP() async throws {
+        let workingDirectory = URL(filePath: "/tmp/nest")
+        let zipURL = try #require(URL(string: "https://example.com/artifactbundle.zip"))
+        let httpClient = MockHTTPClient(mockFileSystem: fileSystem)
+        httpClient.dummyData = [zipURL: try Data(contentsOf: artifactBundlePath)]
+        let fetcher = ArtifactBundleFetcher(
+            workingDirectory: workingDirectory,
+            executorBuilder: executorBuilder,
+            fileSystem: fileSystem,
+            fileDownloader: NestFileDownloader(httpClient: httpClient),
+            nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            artifactBundleZIPCacheOption: .disableCache,
+            logger: logger
+        )
+
+        _ = try await fetcher.downloadArtifactBundle(url: zipURL, checksum: .skip)
+
+        let temporaryFiles = try fileSystem.contentsOfDirectory(atPath: fileSystem.temporaryDirectory.path())
+        #expect(!temporaryFiles.contains(where: { $0.hasPrefix("nest-artifact-bundle-") }))
+        #expect(!fileSystem.fileExists(atPath: fileSystem.temporaryDirectory.appending(component: zipURL.lastPathComponent).path()))
+    }
+
+    @Test
+    func downloadArtifactBundleUsesUserScopeCacheBeforeNetwork() async throws {
+        let workingDirectory = URL(filePath: "/tmp/nest")
+        let zipURL = try #require(URL(string: "https://example.com/artifactbundle.zip"))
+        let zipData = try Data(contentsOf: artifactBundlePath)
+        let httpClient = MockHTTPClient(mockFileSystem: fileSystem)
+        let zipCache = ArtifactBundleZIPCache(directory: URL(filePath: "/User/Library/Caches/nest/artifact-bundle-zips"))
+        let cachedZIPURL = zipCache.fileURL(for: zipURL)
+        try fileSystem.createDirectory(at: cachedZIPURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try fileSystem.write(zipData, to: cachedZIPURL)
+
+        let fileDownloader = NestFileDownloader(httpClient: httpClient)
+        let fetcher = ArtifactBundleFetcher(
+            workingDirectory: workingDirectory,
+            executorBuilder: executorBuilder,
+            fileSystem: fileSystem,
+            fileDownloader: fileDownloader,
+            nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            artifactBundleZIPCacheOption: .enableCache(zipCache),
+            logger: logger
+        )
+
+        let result = try await fetcher.downloadArtifactBundle(url: zipURL, checksum: .skip)
+
+        #expect(result == [ExecutableBinary(
+            commandName: "foo",
+            binaryPath: URL(filePath: "/tmp/nest/artifactbundle/foo.artifactbundle/foo-1.0.0-macosx/bin/foo"),
+            version: "1.0.0",
+            manufacturer: .artifactBundle(sourceInfo: ArtifactBundleSourceInfo(zipURL: zipURL, repository: nil))
+        )])
+    }
+
+    @Test
+    func downloadArtifactBundleReplacesUnusableUserScopeCache() async throws {
+        let workingDirectory = URL(filePath: "/tmp/nest")
+        let zipURL = try #require(URL(string: "https://example.com/artifactbundle.zip"))
+        let zipData = try Data(contentsOf: artifactBundlePath)
+        let httpClient = MockHTTPClient(mockFileSystem: fileSystem)
+        httpClient.dummyData = [zipURL: zipData]
+        let cacheDirectory = URL(filePath: "/User/Library/Caches/nest/artifact-bundle-zips")
+        let zipCache = ArtifactBundleZIPCache(directory: cacheDirectory)
+        let cachedZIPURL = zipCache.fileURL(for: zipURL)
+        try fileSystem.createDirectory(
+            at: cachedZIPURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try fileSystem.write(Data("invalid ZIP".utf8), to: cachedZIPURL)
+
+        let fileDownloader = NestFileDownloader(httpClient: httpClient)
+        let fetcher = ArtifactBundleFetcher(
+            workingDirectory: workingDirectory,
+            executorBuilder: executorBuilder,
+            fileSystem: fileSystem,
+            fileDownloader: fileDownloader,
+            nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(
+                httpClient: httpClient,
+                registryConfigs: nil,
+                logger: logger
+            ),
+            artifactBundleZIPCacheOption: .enableCache(zipCache),
+            logger: logger
+        )
+
+        let result = try await fetcher.downloadArtifactBundle(url: zipURL, checksum: .skip)
+
+        #expect(result == [ExecutableBinary(
+            commandName: "foo",
+            binaryPath: URL(filePath: "/tmp/nest/artifactbundle/foo.artifactbundle/foo-1.0.0-macosx/bin/foo"),
+            version: "1.0.0",
+            manufacturer: .artifactBundle(sourceInfo: ArtifactBundleSourceInfo(zipURL: zipURL, repository: nil))
+        )])
+        #expect(try fileSystem.data(at: cachedZIPURL) == zipData)
+    }
+
+    @Test
+    func downloadArtifactBundlePreservesUserScopeCacheWhenDestinationIsUnavailable() async throws {
+        let workingDirectory = URL(filePath: "/tmp/nest")
+        let zipURL = try #require(URL(string: "https://example.com/artifactbundle.zip"))
+        let zipData = try Data(contentsOf: artifactBundlePath)
+        let httpClient = MockHTTPClient(mockFileSystem: fileSystem)
+        let zipCache = ArtifactBundleZIPCache(directory: URL(filePath: "/User/Library/Caches/nest/artifact-bundle-zips"))
+        let cachedZIPURL = zipCache.fileURL(for: zipURL)
+        try fileSystem.createDirectory(at: cachedZIPURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try fileSystem.write(zipData, to: cachedZIPURL)
+        fileSystem.unzipError = .destinationUnavailable
+
+        let fetcher = ArtifactBundleFetcher(
+            workingDirectory: workingDirectory,
+            executorBuilder: executorBuilder,
+            fileSystem: fileSystem,
+            fileDownloader: NestFileDownloader(httpClient: httpClient),
+            nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            artifactBundleZIPCacheOption: .enableCache(zipCache),
+            logger: logger
+        )
+
+        await #expect(throws: MockFileSystem.MockFileSystemError.destinationUnavailable) {
+            try await fetcher.downloadArtifactBundle(url: zipURL, checksum: .skip)
+        }
+        #expect(try fileSystem.data(at: cachedZIPURL) == zipData)
+    }
+
+    @Test
+    func downloadArtifactBundleDoesNotUseUserScopeCacheWhenDisabled() async throws {
+        let workingDirectory = URL(filePath: "/tmp/nest")
+        let zipURL = try #require(URL(string: "https://example.com/artifactbundle.zip"))
+        let zipData = try Data(contentsOf: artifactBundlePath)
+        let httpClient = MockHTTPClient(mockFileSystem: fileSystem)
+        let zipCache = ArtifactBundleZIPCache(directory: URL(filePath: "/User/Library/Caches/nest/artifact-bundle-zips"))
+        let cachedZIPURL = zipCache.fileURL(for: zipURL)
+        try fileSystem.createDirectory(at: cachedZIPURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try fileSystem.write(zipData, to: cachedZIPURL)
+
+        let fileDownloader = NestFileDownloader(httpClient: httpClient)
+        let fetcher = ArtifactBundleFetcher(
+            workingDirectory: workingDirectory,
+            executorBuilder: executorBuilder,
+            fileSystem: fileSystem,
+            fileDownloader: fileDownloader,
+            nestInfoController: NestInfoController(directory: nestDirectory, fileSystem: fileSystem),
+            assetRegistryClientBuilder: AssetRegistryClientBuilder(httpClient: httpClient, registryConfigs: nil, logger: logger),
+            artifactBundleZIPCacheOption: .disableCache,
+            logger: logger
+        )
+
+        await #expect(throws: (any Error).self) {
+            try await fetcher.downloadArtifactBundle(url: zipURL, checksum: .skip)
+        }
     }
 }
 

--- a/Tests/NestKitTests/ArtifactBundleZIPCacheTests.swift
+++ b/Tests/NestKitTests/ArtifactBundleZIPCacheTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import NestKit
+
+struct ArtifactBundleZIPCacheTests {
+    private let directory = URL(filePath: "/User/Library/Caches/nest/artifact-bundle-zips")
+
+    @Test
+    func cacheFileURLStaysWithinCacheDirectory() throws {
+        let cache = ArtifactBundleZIPCache(directory: directory)
+        let remoteURL = try #require(URL(string: "https://example.com/%2E%2E/%2E%2E/%2E%2E/%2E%2E/archive.zip"))
+
+        let cacheFileURL = cache.fileURL(for: remoteURL)
+        let actualPathComponents = cacheFileURL.standardizedFileURL.pathComponents
+        let cacheDirectoryPathComponents = directory.standardizedFileURL.pathComponents
+
+        #expect(actualPathComponents.starts(with: cacheDirectoryPathComponents))
+        #expect(!actualPathComponents.dropFirst(cacheDirectoryPathComponents.count).contains(".."))
+        #expect(cacheFileURL.pathExtension == "zip")
+    }
+
+    @Test
+    func cacheFileURLPreservesReadableOrigin() throws {
+        let cache = ArtifactBundleZIPCache(directory: directory)
+        let remoteURLString = """
+            https://github.com/realm/SwiftLint/releases/download/1.0.0/\
+            SwiftLintBinary-macos.artifactbundle.zip
+            """
+        let remoteURL = try #require(URL(string: remoteURLString))
+
+        let cacheFileURL = cache.fileURL(for: remoteURL)
+        let relativePathComponents = cacheFileURL.pathComponents.dropFirst(directory.pathComponents.count)
+
+        #expect(Array(relativePathComponents.dropLast()) == [
+            "https",
+            "github.com",
+            "realm",
+            "SwiftLint",
+            "releases",
+            "download",
+            "1.0.0"
+        ])
+        #expect(relativePathComponents.last?.hasPrefix("SwiftLintBinary-macos.artifactbundle-") == true)
+    }
+
+    @Test(arguments: [
+        ("https://example.com/archive.zip?version=1", "https://example.com/archive.zip?version=2"),
+        ("https://example.com:443/archive.zip", "https://example.com:8443/archive.zip")
+    ])
+    func distinctRemoteURLsUseDistinctCacheFiles(firstURLString: String, secondURLString: String) throws {
+        let cache = ArtifactBundleZIPCache(directory: directory)
+        let firstURL = try #require(URL(string: firstURLString))
+        let secondURL = try #require(URL(string: secondURLString))
+
+        #expect(cache.fileURL(for: firstURL) != cache.fileURL(for: secondURL))
+    }
+
+    @Test
+    func fragmentDoesNotAffectCacheIdentity() throws {
+        let cache = ArtifactBundleZIPCache(directory: directory)
+        let firstURL = try #require(URL(string: "https://example.com/archive.zip#first"))
+        let secondURL = try #require(URL(string: "https://example.com/archive.zip#second"))
+
+        #expect(cache.fileURL(for: firstURL) == cache.fileURL(for: secondURL))
+    }
+}

--- a/Tests/NestKitTests/FileSystemTests.swift
+++ b/Tests/NestKitTests/FileSystemTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import NestKit
+import Testing
+
+struct FileSystemTests {
+    @Test
+    func copyItemAtomicallyReplacesDestination() throws {
+        let fileSystem = FileManager.default
+        let directory = fileSystem.temporaryDirectory.appending(
+            component: "nest-file-system-tests-\(UUID().uuidString)"
+        )
+        let cacheDirectory = directory.appending(component: "cache")
+        let sourceURL = directory.appending(component: "source.zip")
+        let destinationURL = cacheDirectory.appending(component: "destination.zip")
+        try fileSystem.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+        defer { try? fileSystem.removeItem(at: directory) }
+        try fileSystem.write(Data("new".utf8), to: sourceURL)
+        try fileSystem.write(Data("old".utf8), to: destinationURL)
+
+        try fileSystem.copyItemAtomicallyReplacingDestination(at: sourceURL, to: destinationURL)
+
+        #expect(try fileSystem.data(at: sourceURL) == Data("new".utf8))
+        #expect(try fileSystem.data(at: destinationURL) == Data("new".utf8))
+        #expect(try fileSystem.contentsOfDirectory(atPath: cacheDirectory.path()) == ["destination.zip"])
+    }
+}

--- a/Tests/NestTests/Arguments/CacheOptionsArgumentsTests.swift
+++ b/Tests/NestTests/Arguments/CacheOptionsArgumentsTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import nest
+
+struct CacheOptionsArgumentsTests {
+    @Test
+    func installCommandAcceptsUserScopeCacheOption() throws {
+        let command = try InstallCommand.parse(["owner/repo", "--enable-user-scope-cache"])
+
+        #expect(command.cacheOptions.enableUserScopeCache)
+    }
+
+    @Test
+    func bootstrapCommandAcceptsUserScopeCacheOption() throws {
+        let command = try BootstrapCommand.parse(["nestfile.yaml", "--enable-user-scope-cache"])
+
+        #expect(command.cacheOptions.enableUserScopeCache)
+    }
+
+    @Test
+    func runCommandAcceptsUserScopeCacheOption() throws {
+        let command = try RunCommand.parse(["--enable-user-scope-cache", "owner/repo"])
+
+        #expect(command.cacheOptions.enableUserScopeCache)
+        #expect(command.arguments == ["owner/repo"])
+    }
+}


### PR DESCRIPTION
## Summary
- Add user-scope cache support to artifact bundle fetching and ZIP cache handling
- Thread cache options through CLI commands and configuration so cache behavior can be controlled consistently
- Update file-system abstractions, mocks, and README guidance to match the new cache flow
- Extend tests for cache options, ZIP cache behavior, file-system interactions, and bundle fetching

## Testing
- Added and updated unit tests for cache option parsing and cache behavior
- Verified related CLI and NestKit test coverage for the new user-scope cache path